### PR TITLE
[feat] 슬라이스 기반 페이지네이션 공통 응답 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/common/response/ApiSliceResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/response/ApiSliceResponse.java
@@ -1,0 +1,60 @@
+package org.example.ootoutfitoftoday.common.response;
+
+import lombok.Builder;
+import org.example.ootoutfitoftoday.common.exception.SuccessCode;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record ApiSliceResponse<T>(
+        HttpStatus httpStatus,
+        int statusValue,
+        boolean success,
+        String code,
+        String message,
+        SliceData<T> data,
+        LocalDateTime timestamp
+) {
+
+    /**
+     * 성공적인 요청에 대한 페이징 응답을 반환하는 메서드
+     * 주어진 데이터를 포함하여 HTTP 상태 코드와 함께 응답을 반환
+     *
+     * @param sliceData 요청 성공 시 반환할 페이징 데이터
+     * @return HTTP 상태코드 성공 응답과 함께 ApiSliceResponse<T>
+     */
+    public static <T> ResponseEntity<ApiSliceResponse<T>> success(Slice<T> sliceData, SuccessCode successCode) {
+
+        return ResponseEntity.status(successCode.getHttpStatus()).body(
+                ApiSliceResponse.<T>builder()
+                        .httpStatus(successCode.getHttpStatus())
+                        .statusValue(successCode.getHttpStatus().value())
+                        .success(true)
+                        .code(successCode.getCode())
+                        .message(successCode.getMessage())
+                        .data(SliceData.<T>builder()
+                                .content(sliceData.getContent())
+                                .size(sliceData.getSize())
+                                .number(sliceData.getNumber())
+                                .hasNext(sliceData.hasNext())
+                                .hasPrevious(sliceData.hasPrevious())
+                                .build())
+                        .timestamp(java.time.LocalDateTime.now())
+                        .build()
+        );
+    }
+
+    @Builder
+    private record SliceData<T>(
+            List<T> content,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious
+    ) {
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- #57  --> 

- Closes #57 

## 📝 요약(Summary)
- 커서 기반 데이터를 불러오기 위해서 슬라이스 기반 페이지 네이션 공통 응답이 필요할 것 생각되어 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
