### PR TITLE
[feat] 공개 옷장 리스트 조회 API 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
@@ -2,16 +2,17 @@ package org.example.ootoutfitoftoday.domain.closet.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.response.ApiPageResponse;
 import org.example.ootoutfitoftoday.common.response.ApiResponse;
 import org.example.ootoutfitoftoday.domain.closet.dto.request.ClosetSaveRequest;
+import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetGetPublicResponse;
 import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetSaveResponse;
 import org.example.ootoutfitoftoday.domain.closet.exception.ClosetSuccessCode;
 import org.example.ootoutfitoftoday.domain.closet.service.command.ClosetCommandService;
+import org.example.ootoutfitoftoday.domain.closet.service.query.ClosetQueryService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,14 +20,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClosetController {
 
     private final ClosetCommandService closetCommandService;
+    private final ClosetQueryService closetQueryService;
 
     // 옷장 등록
     @PostMapping
-    public ResponseEntity<ApiResponse<ClosetSaveResponse>> createCloset(
-            @Valid @RequestBody ClosetSaveRequest closetSaveRequest
-    ) {
+    public ResponseEntity<ApiResponse<ClosetSaveResponse>> createCloset(@Valid @RequestBody ClosetSaveRequest closetSaveRequest) {
         ClosetSaveResponse closetSaveResponse = closetCommandService.createCloset(closetSaveRequest);
 
         return ApiResponse.success(closetSaveResponse, ClosetSuccessCode.CLOSET_CREATED);
+    }
+
+    // 공개 옷장 리스트 조회
+    @GetMapping("/public")
+    public ResponseEntity<ApiPageResponse<ClosetGetPublicResponse>> getPublicClosets(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size, @RequestParam(defaultValue = "createdAt") String sort, @RequestParam(defaultValue = "DESC") String direction) {
+
+        Page<ClosetGetPublicResponse> closetGetPublicResponses = closetQueryService.getPublicClosets(page, size, sort, direction);
+
+        return ApiPageResponse.success(closetGetPublicResponses, ClosetSuccessCode.CLOSET_GET_PUBLIC_OK);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
@@ -9,7 +9,7 @@ import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetGetPublicRe
 import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetSaveResponse;
 import org.example.ootoutfitoftoday.domain.closet.exception.ClosetSuccessCode;
 import org.example.ootoutfitoftoday.domain.closet.service.command.ClosetCommandService;
-import org.example.ootoutfitoftoday.domain.closet.service.query.ClosetQueryService;
+import org.example.ootoutfitoftoday.domain.closet.service.query.ClosetQueryServiceImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,11 +20,13 @@ import org.springframework.web.bind.annotation.*;
 public class ClosetController {
 
     private final ClosetCommandService closetCommandService;
-    private final ClosetQueryService closetQueryService;
+    private final ClosetQueryServiceImpl closetQueryService;
 
     // 옷장 등록
     @PostMapping
-    public ResponseEntity<ApiResponse<ClosetSaveResponse>> createCloset(@Valid @RequestBody ClosetSaveRequest closetSaveRequest) {
+    public ResponseEntity<ApiResponse<ClosetSaveResponse>> createCloset(
+            @Valid @RequestBody ClosetSaveRequest closetSaveRequest
+    ) {
         ClosetSaveResponse closetSaveResponse = closetCommandService.createCloset(closetSaveRequest);
 
         return ApiResponse.success(closetSaveResponse, ClosetSuccessCode.CLOSET_CREATED);

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/response/ClosetGetPublicResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/response/ClosetGetPublicResponse.java
@@ -1,0 +1,29 @@
+package org.example.ootoutfitoftoday.domain.closet.dto.response;
+
+import org.example.ootoutfitoftoday.domain.closet.entity.Closet;
+
+import java.time.LocalDateTime;
+
+public record ClosetGetPublicResponse(
+
+        Long closetId,
+        String name,
+        String description,
+        String imageUrl,
+        Boolean isPublic,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ClosetGetPublicResponse from(Closet closet) {
+
+        return new ClosetGetPublicResponse(
+                closet.getId(),
+                closet.getName(),
+                closet.getDescription(),
+                closet.getImageUrl(),
+                closet.getIsPublic(),
+                closet.getCreatedAt(),
+                closet.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/exception/ClosetSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/exception/ClosetSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ClosetSuccessCode implements SuccessCode {
 
-    CLOSET_CREATED("CLOSET_CREATED", HttpStatus.CREATED, "옷장이 등록되었습니다.");
+    CLOSET_CREATED("CLOSET_CREATED", HttpStatus.CREATED, "옷장이 등록되었습니다."),
+    CLOSET_GET_PUBLIC_OK("CLOSET_GET_PUBLIC_OK", HttpStatus.OK, "공개 옷장 리스트를 조회했습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/repository/ClosetRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/repository/ClosetRepository.java
@@ -1,7 +1,17 @@
 package org.example.ootoutfitoftoday.domain.closet.repository;
 
 import org.example.ootoutfitoftoday.domain.closet.entity.Closet;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClosetRepository extends JpaRepository<Closet, Long> {
+
+    /**
+     * 공개 옷장 리스트 조회
+     * 리스트(전체): all
+     * 공개: IsPublic = true
+     * 삭제: Isdeleted = false
+     */
+    Page<Closet> findAllByIsPublicTrueAndIsDeletedFalse(Pageable pageable);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/query/ClosetQueryService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/query/ClosetQueryService.java
@@ -1,0 +1,9 @@
+package org.example.ootoutfitoftoday.domain.closet.service.query;
+
+import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetGetPublicResponse;
+import org.springframework.data.domain.Page;
+
+public interface ClosetQueryService {
+
+    Page<ClosetGetPublicResponse> getPublicClosets(int page, int size, String sort, String direction);
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/query/ClosetQueryService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/query/ClosetQueryService.java
@@ -1,9 +1,4 @@
 package org.example.ootoutfitoftoday.domain.closet.service.query;
 
-import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetGetPublicResponse;
-import org.springframework.data.domain.Page;
-
 public interface ClosetQueryService {
-
-    Page<ClosetGetPublicResponse> getPublicClosets(int page, int size, String sort, String direction);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/query/ClosetQueryServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/query/ClosetQueryServiceImpl.java
@@ -1,0 +1,36 @@
+package org.example.ootoutfitoftoday.domain.closet.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetGetPublicResponse;
+import org.example.ootoutfitoftoday.domain.closet.entity.Closet;
+import org.example.ootoutfitoftoday.domain.closet.repository.ClosetRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClosetQueryServiceImpl implements ClosetQueryService {
+
+    private final ClosetRepository closetRepository;
+
+    // 공개 옷장 리스트 조회
+    public Page<ClosetGetPublicResponse> getPublicClosets(
+            int page,
+            int size,
+            String sort,
+            String direction
+    ) {
+        Sort sortObj = Sort.by(Sort.Direction.fromString(direction), sort);
+
+        Pageable pageable = PageRequest.of(page, size, sortObj);
+
+        Page<Closet> closets = closetRepository.findAllByIsPublicTrueAndIsDeletedFalse(pageable);
+
+        return closets.map(ClosetGetPublicResponse::from);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #21 
공개 옷장 리스트를 최신순으로 전체 조회할 수 있는 API를 구현했습니다.
## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 공개 여부가 true이고 삭제 여부가 false인 옷장만 전체 조회
- 오프셋 기반 페이지네이션 적용
- 정렬 기준 및 방향 설정 가능 (기본값: 최신순)
- 빈 리스트도 정상 응답 처리
- Command/Query 분리로 조회 로직을 별도 서비스로 관리
- @Transactional(readOnly = true)로 조회 성능 최적화
- record의 기본 생성자 활용으로 불필요한 Builder 제거

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 인증인가 구현 전, 옷장 데이터 있을 때 응답 (로그인 구현 시, 리팩토링 후 다시 테스트 예정)
<img width="1249" height="895" alt="스크린샷 2025-10-19 16 08 35" src="https://github.com/user-attachments/assets/ce077dc5-8a49-45cb-9977-011c350f1e32" />
<img width="1249" height="895" alt="스크린샷 2025-10-19 16 08 43" src="https://github.com/user-attachments/assets/2c190a0b-14eb-40df-946e-0e9b193f533b" />

- 옷장 데이터 없을 때 빈리스트 응답(인증인가 구현 전,후)
<img width="1249" height="485" alt="스크린샷 2025-10-19 16 09 29" src="https://github.com/user-attachments/assets/11a81295-2c43-4c74-9408-61e7597ff6ed" />

- URL 잘못 입력 시 응답
<img width="1249" height="485" alt="스크린샷 2025-10-19 16 09 44" src="https://github.com/user-attachments/assets/696398bc-bc37-44b6-92bb-47858e8fc46a" />


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
