### PR TITLE
[feat] 옷장 삭제 API 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
@@ -139,4 +139,25 @@ public class ClosetController {
 
         return ApiResponse.success(closetUpdateResponse, ClosetSuccessCode.CLOSET_UPDATE_OK);
     }
+
+    /**
+     * 옷장 삭제
+     *
+     * @param authUser: 인증된 사용자 정보
+     * @param closetId: 삭제할 옷장의 ID
+     * @return ClosetDeleteResponse 삭제된 옷장 ID와 삭제 시간
+     */
+    @DeleteMapping("/{closetId}")
+    public ResponseEntity<ApiResponse<ClosetDeleteResponse>> deleteCloset(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long closetId
+    ) {
+
+        ClosetDeleteResponse response = closetCommandService.deleteCloset(
+                authUser.getUserId(),
+                closetId
+        );
+
+        return ApiResponse.success(response, ClosetSuccessCode.CLOSET_DELETE_OK);
+    }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/response/ClosetDeleteResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/response/ClosetDeleteResponse.java
@@ -1,0 +1,17 @@
+package org.example.ootoutfitoftoday.domain.closet.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ClosetDeleteResponse(
+
+        Long closetId,
+        LocalDateTime deletedAt
+) {
+    public static ClosetDeleteResponse of(
+            Long closetId,
+            LocalDateTime deletedAt
+    ) {
+
+        return new ClosetDeleteResponse(closetId, deletedAt);
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/exception/ClosetSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/exception/ClosetSuccessCode.java
@@ -13,7 +13,8 @@ public enum ClosetSuccessCode implements SuccessCode {
     CLOSETS_GET_PUBLIC_OK("CLOSETS_GET_PUBLIC_OK", HttpStatus.OK, "공개 옷장 리스트를 조회했습니다."),
     CLOSET_GET_OK("CLOSET_GET_OK", HttpStatus.OK, "옷장 상세 정보를 조회했습니다."),
     CLOSETS_GET_MY_OK("CLOSETS_GET_MY_OK", HttpStatus.OK, "내 옷장 리스트를 조회했습니다."),
-    CLOSET_UPDATE_OK("CLOSET_UPDATE_OK", HttpStatus.OK, "옷장 정보가 수정되었습니다.");
+    CLOSET_UPDATE_OK("CLOSET_UPDATE_OK", HttpStatus.OK, "옷장 정보가 수정되었습니다."),
+    CLOSET_DELETE_OK("CLOSET_DELETE_OK", HttpStatus.OK, "옷장이 삭제되었습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandService.java
@@ -2,6 +2,7 @@ package org.example.ootoutfitoftoday.domain.closet.service.command;
 
 import org.example.ootoutfitoftoday.domain.closet.dto.request.ClosetSaveRequest;
 import org.example.ootoutfitoftoday.domain.closet.dto.request.ClosetUpdateRequest;
+import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetDeleteResponse;
 import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetSaveResponse;
 import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetUpdateResponse;
 
@@ -18,5 +19,11 @@ public interface ClosetCommandService {
             Long userId,
             Long closetId,
             ClosetUpdateRequest request
+    );
+
+    // 옷장 삭제
+    ClosetDeleteResponse deleteCloset(
+            Long userId,
+            Long closetId
     );
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
@@ -85,7 +85,7 @@ public class ClosetCommandServiceImpl implements ClosetCommandService {
                 .orElseThrow(() -> new ClosetException(ClosetErrorCode.CLOSET_NOT_FOUND));
 
         if (closet.isDeleted()) {
-            throw new ClosetException(ClosetErrorCode.CLOSET_NOT_FOUND);
+            throw new ClosetException(ClosetErrorCode.CLOSET_DELETED);
         }
 
         if (!Objects.equals(closet.getUserId(), userId)) {

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
@@ -3,6 +3,7 @@ package org.example.ootoutfitoftoday.domain.closet.service.command;
 import lombok.RequiredArgsConstructor;
 import org.example.ootoutfitoftoday.domain.closet.dto.request.ClosetSaveRequest;
 import org.example.ootoutfitoftoday.domain.closet.dto.request.ClosetUpdateRequest;
+import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetDeleteResponse;
 import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetSaveResponse;
 import org.example.ootoutfitoftoday.domain.closet.dto.response.ClosetUpdateResponse;
 import org.example.ootoutfitoftoday.domain.closet.entity.Closet;
@@ -13,6 +14,8 @@ import org.example.ootoutfitoftoday.domain.user.entity.User;
 import org.example.ootoutfitoftoday.domain.user.service.query.UserQueryService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -69,5 +72,28 @@ public class ClosetCommandServiceImpl implements ClosetCommandService {
         );
 
         return ClosetUpdateResponse.from(updatedCloset);
+    }
+
+    // 옷장 삭제
+    @Override
+    public ClosetDeleteResponse deleteCloset(
+            Long userId,
+            Long closetId
+    ) {
+
+        Closet closet = closetRepository.findById(closetId)
+                .orElseThrow(() -> new ClosetException(ClosetErrorCode.CLOSET_NOT_FOUND));
+
+        if (closet.isDeleted()) {
+            throw new ClosetException(ClosetErrorCode.CLOSET_NOT_FOUND);
+        }
+
+        if (!Objects.equals(closet.getUserId(), userId)) {
+            throw new ClosetException(ClosetErrorCode.CLOSET_FORBIDDEN);
+        }
+
+        closet.softDelete();
+
+        return ClosetDeleteResponse.of(closet.getId(), closet.getDeletedAt());
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #25 
- 로그인한 사용자가 본인의 옷장 정보를 삭제할 수 있는 API를 구현했습니다.
- 삭제는 실제 DB에서 제거하지 않고 soft delete 방식으로 처리되며, 삭제된 옷장은 이후 조회되지 않습니다.

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- closetId를 PathVariable로 받아 해당 옷장 삭제
- 본인의 옷장인지 소유권 검증 (userId 일치 확인)
- 삭제된 옷장은 isDeleted = true, deletedAt에 삭제 시간 기록
- ClosetDeleteResponse를 통해 삭제 결과 반환
- @Transactional을 통해 변경 감지 기반 soft delete 처리
- 실제 삭제 대신 soft delete를 사용하여 데이터 보존 및 복구 가능성 확보
- 다른 사용자의 옷장 삭제 방지 (403 Forbidden 처리)
- 삭제된 옷장은 이후 조회 API에서 제외되도록 설계
- Objects.equals()를 사용하여 NPE 방지 및 가독성 향상

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 삭제 성공 케이스 (200 OK)
<img width="1249" height="693" alt="스크린샷 2025-10-20 14 21 41" src="https://github.com/user-attachments/assets/d24eb56f-e2e2-41ff-a76c-d07f86062223" />

- 다른 사용자의 옷장 수정 시도 (403 Forbidden)
<img width="1249" height="640" alt="스크린샷 2025-10-20 14 21 26" src="https://github.com/user-attachments/assets/cdd0ea2a-c468-462b-8d8d-d64cb63bdac9" />

- 존재하지 않는 옷장 (404 Not Found)
<img width="1249" height="693" alt="스크린샷 2025-10-20 14 31 58" src="https://github.com/user-attachments/assets/2d4e622c-48e6-455a-947b-9dd871728abf" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
