### PR TITLE
[feat] 채팅방 삭제 API 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/exception/ChatParticipatingUserErrorCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/exception/ChatParticipatingUserErrorCode.java
@@ -1,0 +1,17 @@
+package org.example.ootoutfitoftoday.domain.chatparticipatinguser.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.ootoutfitoftoday.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ChatParticipatingUserErrorCode implements ErrorCode {
+
+    NOT_MATCH_CHATROOM_AND_USER("NOT_MATCH_CHATROOM_AND_USER", HttpStatus.BAD_REQUEST, "채팅방과 매치되는 유저가 없습니다.");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/exception/ChatParticipatingUserErrorCodeException.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/exception/ChatParticipatingUserErrorCodeException.java
@@ -1,0 +1,9 @@
+package org.example.ootoutfitoftoday.domain.chatparticipatinguser.exception;
+
+import org.example.ootoutfitoftoday.common.exception.GlobalException;
+
+public class ChatParticipatingUserErrorCodeException extends GlobalException {
+    public ChatParticipatingUserErrorCodeException(ChatParticipatingUserErrorCode chatParticipatingUserErrorCodeExceptionErrorCode) {
+        super(chatParticipatingUserErrorCodeExceptionErrorCode);
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/repository/ChatParticipatingUserRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/repository/ChatParticipatingUserRepository.java
@@ -7,6 +7,7 @@ import org.example.ootoutfitoftoday.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatParticipatingUserRepository extends JpaRepository<ChatParticipatingUser, ChatParticipatingUserId> {
 
@@ -14,5 +15,5 @@ public interface ChatParticipatingUserRepository extends JpaRepository<ChatParti
 
     List<ChatParticipatingUser> findAllByChatroom(Chatroom chatroom);
 
-    ChatParticipatingUser findByChatroomAndUser(Chatroom chatroom, User user);
+    Optional<ChatParticipatingUser> findByChatroomAndUser(Chatroom chatroom, User user);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/repository/ChatParticipatingUserRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/repository/ChatParticipatingUserRepository.java
@@ -13,4 +13,6 @@ public interface ChatParticipatingUserRepository extends JpaRepository<ChatParti
     List<ChatParticipatingUser> findByUserAndIsDeletedFalse(User user);
 
     List<ChatParticipatingUser> findAllByChatroom(Chatroom chatroom);
+
+    ChatParticipatingUser findByChatroomAndUser(Chatroom chatroom, User user);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/command/ChatParticipatingUserCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/command/ChatParticipatingUserCommandService.java
@@ -1,5 +1,6 @@
 package org.example.ootoutfitoftoday.domain.chatparticipatinguser.service.command;
 
+import org.example.ootoutfitoftoday.domain.chatparticipatinguser.entity.ChatParticipatingUser;
 import org.example.ootoutfitoftoday.domain.chatroom.entity.Chatroom;
 import org.example.ootoutfitoftoday.domain.salepost.entity.SalePost;
 import org.example.ootoutfitoftoday.domain.user.entity.User;
@@ -8,4 +9,7 @@ public interface ChatParticipatingUserCommandService {
 
     // 하나의 채팅방 id와 채팅방에 해당하는 각 유저들의 id를 복합키로 사용하기 위해 저장하는 메서드
     void saveKeys(Chatroom chatroom, SalePost salePost, User user);
+
+    // ChatParticipatingUser 소프트 딜리트
+    void softDeleteChatParticipatingUser(ChatParticipatingUser chatParticipatingUser);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/command/ChatParticipatingUserCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/command/ChatParticipatingUserCommandServiceImpl.java
@@ -39,4 +39,10 @@ public class ChatParticipatingUserCommandServiceImpl implements ChatParticipatin
         // 전체 저장
         chatParticipatingUserRepository.saveAll(java.util.List.of(buyerParticipation, sellerParticipation));
     }
+
+
+    @Override
+    public void softDeleteChatParticipatingUser(ChatParticipatingUser chatParticipatingUser) {
+        chatParticipatingUser.softDelete();
+    }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/command/ChatParticipatingUserCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/command/ChatParticipatingUserCommandServiceImpl.java
@@ -39,8 +39,7 @@ public class ChatParticipatingUserCommandServiceImpl implements ChatParticipatin
         // 전체 저장
         chatParticipatingUserRepository.saveAll(java.util.List.of(buyerParticipation, sellerParticipation));
     }
-
-
+    
     @Override
     public void softDeleteChatParticipatingUser(ChatParticipatingUser chatParticipatingUser) {
         chatParticipatingUser.softDelete();

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/query/ChatParticipatingUserQueryService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/query/ChatParticipatingUserQueryService.java
@@ -13,4 +13,7 @@ public interface ChatParticipatingUserQueryService {
 
     // 채팅방을 통해 참여중인 User 객체들을 얻기 위한 메서드
     List<ChatParticipatingUser> getAllParticipatingUserByChatroom(Chatroom chatroom);
+
+    // 채팅방, 유저를 통해 중간 테이블 데이터 얻기 위한 메서드
+    ChatParticipatingUser getChatroomAndUser(Chatroom chatroom, User user);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/query/ChatParticipatingUserQueryServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/query/ChatParticipatingUserQueryServiceImpl.java
@@ -28,4 +28,10 @@ public class ChatParticipatingUserQueryServiceImpl implements ChatParticipatingU
 
         return chatParticipatingUserRepository.findAllByChatroom(chatroom);
     }
+
+    @Override
+    public ChatParticipatingUser getChatroomAndUser(Chatroom chatroom, User user) {
+
+        return chatParticipatingUserRepository.findByChatroomAndUser(chatroom, user);
+    }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/query/ChatParticipatingUserQueryServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatparticipatinguser/service/query/ChatParticipatingUserQueryServiceImpl.java
@@ -2,6 +2,8 @@ package org.example.ootoutfitoftoday.domain.chatparticipatinguser.service.query;
 
 import lombok.RequiredArgsConstructor;
 import org.example.ootoutfitoftoday.domain.chatparticipatinguser.entity.ChatParticipatingUser;
+import org.example.ootoutfitoftoday.domain.chatparticipatinguser.exception.ChatParticipatingUserErrorCode;
+import org.example.ootoutfitoftoday.domain.chatparticipatinguser.exception.ChatParticipatingUserErrorCodeException;
 import org.example.ootoutfitoftoday.domain.chatparticipatinguser.repository.ChatParticipatingUserRepository;
 import org.example.ootoutfitoftoday.domain.chatroom.entity.Chatroom;
 import org.example.ootoutfitoftoday.domain.user.entity.User;
@@ -32,6 +34,8 @@ public class ChatParticipatingUserQueryServiceImpl implements ChatParticipatingU
     @Override
     public ChatParticipatingUser getChatroomAndUser(Chatroom chatroom, User user) {
 
-        return chatParticipatingUserRepository.findByChatroomAndUser(chatroom, user);
+        return chatParticipatingUserRepository.findByChatroomAndUser(chatroom, user).orElseThrow(
+                () -> new ChatParticipatingUserErrorCodeException(ChatParticipatingUserErrorCode.NOT_MATCH_CHATROOM_AND_USER)
+        );
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/controller/ChatroomController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/controller/ChatroomController.java
@@ -29,7 +29,7 @@ public class ChatroomController {
      *
      * @param chatroomRequest 게시물의 id 정보
      * @param authUser        토큰 정보
-     * @return 값 x 공통 응답만
+     * @return 공통 응답만 반환
      */
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createChatroom(
@@ -64,5 +64,23 @@ public class ChatroomController {
         Slice<ChatroomResponse> chatroomResponses = chatroomQueryService.getChatrooms(userId, pageable);
 
         return ApiSliceResponse.success(chatroomResponses, ChatroomSuccessCode.RETRIEVED_CHATROOMS);
+    }
+
+    /**
+     * 채팅방 삭제 API
+     *
+     * @param authUser   토큰 정보
+     * @param chatroomId 채팅방 아이디
+     * @return 공통 응답만 반환
+     */
+    @DeleteMapping("/{chatroomId}")
+    public ResponseEntity<ApiResponse<Void>> deleteChatroom(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long chatroomId
+    ) {
+        Long userId = authUser.getUserId();
+        chatroomCommandService.deleteChatroom(chatroomId, userId);
+
+        return ApiResponse.success(null, ChatroomSuccessCode.DELETED_CHATROOM);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/exception/ChatroomErrorCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/exception/ChatroomErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ChatroomErrorCode implements ErrorCode {
 
+    NOT_EXIST_CHATROOM("NOT_EXIST_CHATROOM", HttpStatus.BAD_REQUEST, "존재하지 않는 채팅방입니다."),
     EQUAL_SELLER_BUYER("EQUAL_SELLER_BUYER", HttpStatus.BAD_REQUEST, "판매자와 구매자가 동일합니다.");
 
     private final String code;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/exception/ChatroomSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/exception/ChatroomSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ChatroomSuccessCode implements SuccessCode {
 
     CREATED_CHATROOM("CREATED_CHATROOM", HttpStatus.CREATED, "채팅방 생성에 성공하였습니다."),
-    RETRIEVED_CHATROOMS("RETRIEVED_CHATROOMS", HttpStatus.OK, "채팅방 조회에 성공하였습니다.");
+    RETRIEVED_CHATROOMS("RETRIEVED_CHATROOMS", HttpStatus.OK, "채팅방 조회에 성공하였습니다."),
+    DELETED_CHATROOM("DELETED_CHATROOM", HttpStatus.OK, "채팅방 삭제에 성공하였습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/service/command/ChatroomCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/service/command/ChatroomCommandService.java
@@ -5,4 +5,6 @@ import org.example.ootoutfitoftoday.domain.chatroom.dto.request.ChatroomRequest;
 public interface ChatroomCommandService {
 
     void createChatroom(ChatroomRequest chatroomRequest, Long userId);
+
+    void deleteChatroom(Long chatroomId, Long userId);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/service/command/ChatroomCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/service/command/ChatroomCommandServiceImpl.java
@@ -1,7 +1,9 @@
 package org.example.ootoutfitoftoday.domain.chatroom.service.command;
 
 import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.domain.chatparticipatinguser.entity.ChatParticipatingUser;
 import org.example.ootoutfitoftoday.domain.chatparticipatinguser.service.command.ChatParticipatingUserCommandService;
+import org.example.ootoutfitoftoday.domain.chatparticipatinguser.service.query.ChatParticipatingUserQueryService;
 import org.example.ootoutfitoftoday.domain.chatroom.dto.request.ChatroomRequest;
 import org.example.ootoutfitoftoday.domain.chatroom.entity.Chatroom;
 import org.example.ootoutfitoftoday.domain.chatroom.exception.ChatroomErrorCode;
@@ -25,6 +27,7 @@ public class ChatroomCommandServiceImpl implements ChatroomCommandService {
     private final SalePostQueryService salePostQueryService;
     private final UserQueryService userQueryService;
     private final ChatParticipatingUserCommandService chatParticipatingUserCommandService;
+    private final ChatParticipatingUserQueryService chatParticipatingUserQueryService;
 
     // 채팅방 생성
     @Override
@@ -52,5 +55,17 @@ public class ChatroomCommandServiceImpl implements ChatroomCommandService {
         saveChatroom.addChatParticipatingUser(user);
 
         chatParticipatingUserCommandService.saveKeys(saveChatroom, salePost, user);
+    }
+
+    // 채팅방 삭제
+    public void deleteChatroom(Long chatroomId, Long userId) {
+        Chatroom chatroom = chatroomRepository.findById(chatroomId).orElseThrow(
+                () -> new ChatroomException(ChatroomErrorCode.NOT_EXIST_CHATROOM)
+        );
+        User user = userQueryService.findByIdAndIsDeletedFalse(userId);
+
+        ChatParticipatingUser chatParticipatingUser = chatParticipatingUserQueryService.getChatroomAndUser(chatroom, user);
+
+        chatParticipatingUserCommandService.softDeleteChatParticipatingUser(chatParticipatingUser);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/service/command/ChatroomCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/service/command/ChatroomCommandServiceImpl.java
@@ -58,6 +58,7 @@ public class ChatroomCommandServiceImpl implements ChatroomCommandService {
     }
 
     // 채팅방 삭제
+    @Override
     public void deleteChatroom(Long chatroomId, Long userId) {
         Chatroom chatroom = chatroomRepository.findById(chatroomId).orElseThrow(
                 () -> new ChatroomException(ChatroomErrorCode.NOT_EXIST_CHATROOM)


### PR DESCRIPTION
## #️⃣ Issue Number<!--- #34 --> 

- Closes #34 

## 📝 요약(Summary)
- 소프트 딜리트 방식을 이용하여 채팅방 삭제를 구현하였습니다.
- 한사람만 채팅방을 삭제한다고 하여도 채팅방의 데이터가 삭제되는 것은 아닙니다.
- 두 사람 모두가 채팅방을 삭제할 시 채팅방의 데이터가 삭제되게 됩니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어
<img width="1033" height="653" alt="스크린샷 2025-10-20 오후 8 46 28" src="https://github.com/user-attachments/assets/97b688ae-2f01-4a48-bbe4-f8d5343b32bd" />
- 리뷰 많이 달아주세요.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
