### PR TITLE
[feat] 특정 옷장에 등록된 옷 리스트 조회 API 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
@@ -57,7 +57,7 @@ public class ClosetClothesLinkController {
      * @param size      페이지 크기 (기본값: 10)
      * @param sort      정렬 기준 (기본값: createdAt)
      * @param direction 정렬 방향 (기본값: DESC)
-     * @return Page<ClothesInClosetResponse> 옷 목록
+     * @return ApiPageResponse<ClothesInClosetResponse> 옷 목록
      */
     @GetMapping
     public ResponseEntity<ApiPageResponse<ClosetClothesLinkGetResponse>> getClosetClothesLink(

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
@@ -2,12 +2,16 @@ package org.example.ootoutfitoftoday.domain.closetclotheslink.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.response.ApiPageResponse;
 import org.example.ootoutfitoftoday.common.response.ApiResponse;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.request.ClosetClothesLinkRequest;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkGetResponse;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkResponse;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.exception.ClosetClothesLinkSuccessCode;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.service.command.ClosetClothesLinkCommandService;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.service.query.ClosetClothesLinkQueryService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -18,8 +22,16 @@ import org.springframework.web.bind.annotation.*;
 public class ClosetClothesLinkController {
 
     private final ClosetClothesLinkCommandService closetClothesLinkCommandService;
+    private final ClosetClothesLinkQueryService closetClothesLinkQueryService;
 
-    // 해당 옷장에 옷 등록
+    /**
+     * 특정 옷장에 옷 등록
+     *
+     * @param authUser                 인증된 사용자 정보
+     * @param closetId                 옷을 등록할 옷장 ID
+     * @param closetClothesLinkRequest 등록할 옷 ID
+     * @return ClosetClothesLinkResponse 연결 정보
+     */
     @PostMapping
     public ResponseEntity<ApiResponse<ClosetClothesLinkResponse>> createClosetClothesLink(
             @AuthenticationPrincipal AuthUser authUser,
@@ -34,5 +46,37 @@ public class ClosetClothesLinkController {
         );
 
         return ApiResponse.success(closetClothesLinkResponse, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_LINKED);
+    }
+
+    /**
+     * 특정 옷장에 등록된 옷 목록 조회
+     *
+     * @param authUser  인증된 사용자 정보
+     * @param closetId  조회할 옷장 ID
+     * @param page      페이지 번호 (기본값: 0)
+     * @param size      페이지 크기 (기본값: 10)
+     * @param sort      정렬 기준 (기본값: createdAt)
+     * @param direction 정렬 방향 (기본값: DESC)
+     * @return Page<ClothesInClosetResponse> 옷 목록
+     */
+    @GetMapping
+    public ResponseEntity<ApiPageResponse<ClosetClothesLinkGetResponse>> getClosetClothesLink(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long closetId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sort,
+            @RequestParam(defaultValue = "DESC") String direction
+    ) {
+        Page<ClosetClothesLinkGetResponse> closetClothesLinkGetResponses = closetClothesLinkQueryService.getClothesInCloset(
+                authUser.getUserId(),
+                closetId,
+                page,
+                size,
+                sort,
+                direction
+        );
+
+        return ApiPageResponse.success(closetClothesLinkGetResponses, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_LIST_OK);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/dto/response/ClosetClothesLinkGetResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/dto/response/ClosetClothesLinkGetResponse.java
@@ -1,0 +1,29 @@
+package org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response;
+
+import org.example.ootoutfitoftoday.domain.closetclotheslink.entity.ClosetClothesLink;
+import org.example.ootoutfitoftoday.domain.clothes.enums.ClothesColor;
+import org.example.ootoutfitoftoday.domain.clothes.enums.ClothesSize;
+
+public record ClosetClothesLinkGetResponse(
+
+        Long linkId,
+        Long clothesId,
+        Long categoryId,
+        ClothesSize clothesSize,
+        ClothesColor clothesColor,
+        String description
+) {
+    public static ClosetClothesLinkGetResponse from(ClosetClothesLink link) {
+
+        return new ClosetClothesLinkGetResponse(
+                link.getId(),
+                link.getClothes().getId(),
+                link.getClothes().getCategory() != null
+                        ? link.getClothes().getCategory().getId()
+                        : null,
+                link.getClothes().getClothesSize(),
+                link.getClothes().getClothesColor(),
+                link.getClothes().getDescription()
+        );
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/entity/ClosetClothesLink.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/entity/ClosetClothesLink.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.ootoutfitoftoday.common.entity.BaseEntity;
 import org.example.ootoutfitoftoday.domain.closet.entity.Closet;
 import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
 
@@ -12,7 +13,7 @@ import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "closet_clothes_links")
-public class ClosetClothesLink {
+public class ClosetClothesLink extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/exception/ClosetClothesLinkSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/exception/ClosetClothesLinkSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ClosetClothesLinkSuccessCode implements SuccessCode {
 
-    CLOSET_CLOTHES_LINKED("CLOSET_CLOTHES_LINKED", HttpStatus.CREATED, "옷장에 옷이 등록되었습니다.");
+    CLOSET_CLOTHES_LINKED("CLOSET_CLOTHES_LINKED", HttpStatus.CREATED, "옷장에 옷이 등록되었습니다."),
+    CLOSET_CLOTHES_LIST_OK("CLOSET_CLOTHES_LIST_OK", HttpStatus.OK, "옷장에 등록된 옷 리스트를 조회했습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/repository/ClosetClothesLinkRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/repository/ClosetClothesLinkRepository.java
@@ -1,10 +1,15 @@
 package org.example.ootoutfitoftoday.domain.closetclotheslink.repository;
 
 import org.example.ootoutfitoftoday.domain.closetclotheslink.entity.ClosetClothesLink;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClosetClothesLinkRepository extends JpaRepository<ClosetClothesLink, Long> {
 
     // 해당 옷장에 해당 옷이 이미 등록되어 있는지 확인
     boolean existsByClosetIdAndClothesId(Long closetId, Long clothesId);
+
+    // 특정 옷장에 등록된 옷 리스트 조회
+    Page<ClosetClothesLink> findAllByClosetId(Long closetId, Pageable pageable);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/command/ClosetClothesLinkCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/command/ClosetClothesLinkCommandServiceImpl.java
@@ -37,8 +37,8 @@ public class ClosetClothesLinkCommandServiceImpl implements ClosetClothesLinkCom
 
         if (!Objects.equals(closet.getUserId(), userId)) {
             throw new ClosetClothesLinkException(ClosetClothesLinkErrorCode.CLOSET_CLOTHES_FORBIDDEN);
-            
         }
+
         Clothes clothes = clothesQueryService.findClothesById(request.clothesId());
 
         // 중복 연결 체크

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/query/ClosetClothesLinkQueryService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/query/ClosetClothesLinkQueryService.java
@@ -1,0 +1,17 @@
+package org.example.ootoutfitoftoday.domain.closetclotheslink.service.query;
+
+import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkGetResponse;
+import org.springframework.data.domain.Page;
+
+public interface ClosetClothesLinkQueryService {
+
+    // 옷장에 등록된 옷 목록 조회
+    Page<ClosetClothesLinkGetResponse> getClothesInCloset(
+            Long userId,
+            Long closetId,
+            int page,
+            int size,
+            String sort,
+            String direction
+    );
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/query/ClosetClothesLinkQueryServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/query/ClosetClothesLinkQueryServiceImpl.java
@@ -1,0 +1,51 @@
+package org.example.ootoutfitoftoday.domain.closetclotheslink.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.domain.closet.entity.Closet;
+import org.example.ootoutfitoftoday.domain.closet.service.query.ClosetQueryService;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkGetResponse;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.entity.ClosetClothesLink;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.exception.ClosetClothesLinkErrorCode;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.exception.ClosetClothesLinkException;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.repository.ClosetClothesLinkRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClosetClothesLinkQueryServiceImpl implements ClosetClothesLinkQueryService {
+
+    private final ClosetQueryService closetQueryService;
+    private final ClosetClothesLinkRepository closetClothesLinkRepository;
+
+    @Override
+    public Page<ClosetClothesLinkGetResponse> getClothesInCloset(
+            Long userId,
+            Long closetId,
+            int page,
+            int size,
+            String sort,
+            String direction
+    ) {
+
+        Closet closet = closetQueryService.findClosetById(closetId);
+
+        if (!Objects.equals(closet.getUserId(), userId)) {
+            throw new ClosetClothesLinkException(ClosetClothesLinkErrorCode.CLOSET_CLOTHES_FORBIDDEN);
+        }
+
+        Sort sortObj = Sort.by(Sort.Direction.fromString(direction), sort);
+        Pageable pageable = PageRequest.of(page, size, sortObj);
+
+        Page<ClosetClothesLink> links = closetClothesLinkRepository.findAllByClosetId(closetId, pageable);
+
+        return links.map(ClosetClothesLinkGetResponse::from);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #113
- 사용자가 자신이 소유한 옷장에 등록된 옷 목록을 조회할 수 있는 API를 구현했습니다.


## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- closetId를 PathVariable로 받아 해당 옷장에 등록된 옷 목록 조회
- 중간 테이블(ClosetClothesLink)을 통한 다대다 관계 조회
- 오프셋 기반 페이지네이션으로 효율적인 데이터 조회
- 옷장 소유권 검증으로 본인 옷장만 조회 가능
- 등록 시간(createdAt) 기준 정렬로 최근 등록된 옷부터 조회
- ClosetClothesLink 중간 테이블을 활용하여 옷장과 옷의 연결 정보 조회
- Service 계층 분리로 Repository 직접 접근 대신 ClosetQueryService 사용
- 오프셋 기반 페이지네이션으로 대량의 데이터도 효율적으로 처리
- @AuthenticationPrincipal을 활용하여 JWT 토큰에서 userId 자동 추출
- @Transactional(readOnly = true)로 조회 성능 최적화

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 성공 케이스 (200 OK)
<img width="1243" height="902" alt="스크린샷 2025-10-22 03 29 49" src="https://github.com/user-attachments/assets/b0c9103d-668e-44b3-9f6f-a2b084d92fc9" />

- 다른 사용자의 옷장 (403 Forbidden)
<img width="1243" height="385" alt="스크린샷 2025-10-22 03 30 30" src="https://github.com/user-attachments/assets/895b3345-f1d8-4b17-bfd4-1c2ef7f20810" />

- 인증 (403 Forbidden)
<img width="1243" height="749" alt="스크린샷 2025-10-22 03 26 09" src="https://github.com/user-attachments/assets/741602ff-c30f-4e4d-8bde-ffae44b5aac9" />



## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
