### PR TITLE
[feat] 특정 옷장의 옷 삭제 API 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
@@ -69,6 +69,7 @@ public class ClosetClothesLinkController {
             @RequestParam(defaultValue = "createdAt") String sort,
             @RequestParam(defaultValue = "DESC") String direction
     ) {
+
         Page<ClosetClothesLinkGetResponse> closetClothesLinkGetResponses = closetClothesLinkQueryService.getClothesInCloset(
                 authUser.getUserId(),
                 closetId,
@@ -88,6 +89,7 @@ public class ClosetClothesLinkController {
             @PathVariable Long closetId,
             @PathVariable Long clothesId
     ) {
+
         ClosetClothesLinkDeleteResponse closetClothesLinkDeleteResponse = closetClothesLinkCommandService.deleteClosetClothesLink(
                 authUser.getUserId(),
                 closetId,

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
@@ -6,6 +6,7 @@ import org.example.ootoutfitoftoday.common.response.ApiPageResponse;
 import org.example.ootoutfitoftoday.common.response.ApiResponse;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.request.ClosetClothesLinkRequest;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkDeleteResponse;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkGetResponse;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkResponse;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.exception.ClosetClothesLinkSuccessCode;
@@ -78,5 +79,21 @@ public class ClosetClothesLinkController {
         );
 
         return ApiPageResponse.success(closetClothesLinkGetResponses, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_LIST_OK);
+    }
+
+    // 옷장에서 옷 삭제
+    @DeleteMapping("/{clothesId}")
+    public ResponseEntity<ApiResponse<ClosetClothesLinkDeleteResponse>> deleteClosetClothesLink(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long closetId,
+            @PathVariable Long clothesId
+    ) {
+        ClosetClothesLinkDeleteResponse closetClothesLinkDeleteResponse = closetClothesLinkCommandService.deleteClosetClothesLink(
+                authUser.getUserId(),
+                closetId,
+                clothesId
+        );
+
+        return ApiResponse.success(closetClothesLinkDeleteResponse, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_DELETED);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/dto/response/ClosetClothesLinkDeleteResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/dto/response/ClosetClothesLinkDeleteResponse.java
@@ -1,0 +1,18 @@
+package org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response;
+
+public record ClosetClothesLinkDeleteResponse(
+        Long closetId,
+        Long clothesId
+) {
+
+    public static ClosetClothesLinkDeleteResponse of(
+            Long closetId,
+            Long clothesId
+    ) {
+    
+        return new ClosetClothesLinkDeleteResponse(
+                closetId,
+                clothesId
+        );
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/exception/ClosetClothesLinkErrorCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/exception/ClosetClothesLinkErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ClosetClothesLinkErrorCode implements ErrorCode {
 
     CLOSET_CLOTHES_ALREADY_LINKED("CLOTHES_ALREADY_LINKED", HttpStatus.BAD_REQUEST, "이미 옷장에 등록된 옷입니다."),
-    CLOSET_CLOTHES_FORBIDDEN("CLOSET_CLOTHES_FORBIDDEN", HttpStatus.FORBIDDEN, "해당 옷장에 대한 권한이 없습니다.");
+    CLOSET_CLOTHES_FORBIDDEN("CLOSET_CLOTHES_FORBIDDEN", HttpStatus.FORBIDDEN, "해당 옷장에 대한 권한이 없습니다."),
+    CLOTHES_NOT_LINKED("CLOTHES_NOT_LINKED", HttpStatus.NOT_FOUND, "옷장에 등록되지 않은 옷입니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/exception/ClosetClothesLinkSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/exception/ClosetClothesLinkSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ClosetClothesLinkSuccessCode implements SuccessCode {
 
     CLOSET_CLOTHES_LINKED("CLOSET_CLOTHES_LINKED", HttpStatus.CREATED, "옷장에 옷이 등록되었습니다."),
-    CLOSET_CLOTHES_LIST_OK("CLOSET_CLOTHES_LIST_OK", HttpStatus.OK, "옷장에 등록된 옷 리스트를 조회했습니다.");
+    CLOSET_CLOTHES_LIST_OK("CLOSET_CLOTHES_LIST_OK", HttpStatus.OK, "옷장에 등록된 옷 리스트를 조회했습니다."),
+    CLOSET_CLOTHES_DELETED("CLOSET_CLOTHES_DELETED", HttpStatus.OK, "옷장에서 옷이 제거되었습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/repository/ClosetClothesLinkRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/repository/ClosetClothesLinkRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ClosetClothesLinkRepository extends JpaRepository<ClosetClothesLink, Long> {
 
     // 해당 옷장에 해당 옷이 이미 등록되어 있는지 확인
@@ -12,4 +14,15 @@ public interface ClosetClothesLinkRepository extends JpaRepository<ClosetClothes
 
     // 특정 옷장에 등록된 옷 리스트 조회
     Page<ClosetClothesLink> findAllByClosetId(Long closetId, Pageable pageable);
+
+    /**
+     * 특정 옷장과 특정 옷의 연결 조회
+     * 옷장: ClosetId
+     * 옷: ClothesId
+     * 삭제: Isdeleted = false
+     */
+    Optional<ClosetClothesLink> findByClosetIdAndClothesIdAndIsDeletedFalse(
+            Long closetId,
+            Long clothesId
+    );
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/command/ClosetClothesLinkCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/service/command/ClosetClothesLinkCommandService.java
@@ -1,14 +1,22 @@
 package org.example.ootoutfitoftoday.domain.closetclotheslink.service.command;
 
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.request.ClosetClothesLinkRequest;
+import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkDeleteResponse;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkResponse;
 
 public interface ClosetClothesLinkCommandService {
 
-    // 옷장에 옷 등록
+    // 특정 옷장에 옷 등록
     ClosetClothesLinkResponse createClosetClothesLink(
             Long userId,
             Long closetId,
             ClosetClothesLinkRequest request
+    );
+
+    // 특정 옷장에서 옷 제거
+    ClosetClothesLinkDeleteResponse deleteClosetClothesLink(
+            Long userId,
+            Long closetId,
+            Long clothesId
     );
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #27 
- 사용자가 자신의 옷장에 등록된 옷을 제거할 수 있는 API를 구현했습니다. 
- Soft Delete 방식을 적용하여 데이터를 보존하고 복구 가능성을 확보했습니다.


## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- closetId와 clothesId를 PathVariable로 받아 해당 연결 해제
- 실제 옷 데이터는 삭제하지 않고 중간 테이블(ClosetClothesLink)의 연결만 제거
- BaseEntity의 Soft Delete 기능 활용 (isDeleted = true, deletedAt 설정)
- 옷장 소유권 검증으로 본인 옷장에서만 제거 가능
- 연결 존재 여부 확인으로 중복 삭제 방지
- BaseEntity 상속으로 Soft Delete 로직 재사용
- JPA 변경 감지를 활용하여 UPDATE 쿼리 자동 실행
- Repository 직접 접근 대신 ClosetQueryService를 통한 조회

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 성공 케이스 (200 OK)
<img width="1243" height="608" alt="스크린샷 2025-10-22 09 47 04" src="https://github.com/user-attachments/assets/cb84b151-f1f3-4e5c-b750-41b185fec071" />

- 다른 사용자의 옷장 (403 Forbidden)
<img width="1243" height="608" alt="스크린샷 2025-10-22 09 47 37" src="https://github.com/user-attachments/assets/a52b8e6c-156c-4f34-8ae4-287a5e298043" />


- 존재하지 않는 옷장 (404 Not Found)
<img width="1243" height="608" alt="스크린샷 2025-10-22 10 08 15" src="https://github.com/user-attachments/assets/499b536c-addf-4ee9-acb4-f19f50649e4b" />

- 옷장에 등록되지 않은 옷  (404 Not Found)
<img width="1243" height="608" alt="스크린샷 2025-10-22 09 47 11" src="https://github.com/user-attachments/assets/ffc6aac0-b9d2-43e9-a260-4b21f16045a0" />



## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
