### PR TITLE
[chore] dev 환경 설정 AWS Parameter Store 연동 및 민감 정보 외부화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,6 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
 
     // AWS SDK for Java v2 (S3)
-    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,19 @@ dependencies {
     implementation 'org.springframework.security:spring-security-messaging'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+    // AWS Parameter Store
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
+
     // AWS SDK for Java v2 (S3)
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+}
+
+// Spring Cloud AWS BOM (버전 통합 관리)
+dependencyManagement {
+    imports {
+        mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:3.4.0"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,24 +1,23 @@
 spring:
+  config:
+    import:
+      - "aws-parameterstore:/config/dev/"
   datasource:
-    # 개발 서버(RDS) 접속 정보 (환경 변수 사용)
     url: jdbc:mysql://${db.host}:${db.port:3306}/${db.name}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
     username: ${db.username}
     password: ${db.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate # 개발 서버 안정성을 위해 validate로 설정 변경
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 
 springdoc:
-  # Swagger 활성화
-  api-docs:
-    enabled: true
+  api-docs.enabled: true
   swagger-ui:
     enabled: true
     path: /swagger-ui/index.html
     display-request-duration: true
     tryItOutEnabled: true
-
-# 개발 서버 Swagger IP 화이트리스트 설정 (보안 강화 이슈용)
-security:
-  swagger:
-    whitelist-ips: ${SWAGGER_WHITELIST_IPS}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #153

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 개발 서버(dev 프로파일)의 민감한 설정 정보를 소스 코드에서 분리 
- AWS Parameter Store에서 동적으로 가져오도록 Spring Cloud AWS 의존성을 추가하고 설정을 변경
- 이를 통해 설정 관리의 보안과 유연성을 확보

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- AWS 권한: dev 환경을 실행하는 EC2 인스턴스 역할(IAM Role) 또는 CI/CD 사용자(OIDC Role)에게 SSM Parameter Store의 GetParameter 권한이 부여되어 있는지 확인이 필요합니다.
- 이 권한이 없으면 설정 정보를 가져올 수 없어 애플리케이션이 시작되지 않습니다.

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
