### PR TITLE
[chore] Springdoc (Swagger) 의존성 추가 및 전역 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,10 @@ dependencies {
 
     // AWS SDK for Java v2 (S3)
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
 }
 
 // Spring Cloud AWS BOM (버전 통합 관리)

--- a/src/main/java/org/example/ootoutfitoftoday/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/advice/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.ootoutfitoftoday.common.exception.CommonErrorCode;
 import org.example.ootoutfitoftoday.common.exception.ErrorCode;
 import org.example.ootoutfitoftoday.common.exception.GlobalException;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,33 +15,33 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception ex) {
+    public ResponseEntity<Response<Void>> handleException(Exception ex) {
         log.error("알 수 없는 서버 오류 발생 ", ex);
         return ResponseEntity
                 .status(CommonErrorCode.UNEXPECTED_SERVER_ERROR.getHttpStatus())
-                .body(ApiResponse.error(null, CommonErrorCode.UNEXPECTED_SERVER_ERROR));
+                .body(Response.error(null, CommonErrorCode.UNEXPECTED_SERVER_ERROR));
     }
 
     @ExceptionHandler(GlobalException.class)
-    public ResponseEntity<ApiResponse<Void>> handleGlobalException(GlobalException ex) {
+    public ResponseEntity<Response<Void>> handleGlobalException(GlobalException ex) {
         log.error("비즈니스 오류 발생 ", ex);
         return handleExceptionInternal(ex.getErrorCode());
     }
 
-    private ResponseEntity<ApiResponse<Void>> handleExceptionInternal(ErrorCode errorCode) {
+    private ResponseEntity<Response<Void>> handleExceptionInternal(ErrorCode errorCode) {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(ApiResponse.error(null, errorCode));
+                .body(Response.error(null, errorCode));
     }
 
     // Validation Exception은 BAD_REQUEST로 통일
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    public ResponseEntity<Response<String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         // 첫 번째 에러 메시지 가져오기
         String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
 
         return ResponseEntity
                 .status(CommonErrorCode.VALIDATION_ERROR.getHttpStatus())
-                .body(ApiResponse.error(errorMessage, CommonErrorCode.VALIDATION_ERROR));
+                .body(Response.error(errorMessage, CommonErrorCode.VALIDATION_ERROR));
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/common/config/SwaggerConfig.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package org.example.ootoutfitoftoday.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info().title("OOT(Outfit of Today) | 디지털 옷장 관리 서비스 기반 의류 중고 거래 API")
+                        .description("OOT(Outfit of Today) 백엔드 서비스의 공식 API 문서입니다.\n\n" +
+                                "이 플랫폼은 **디지털 옷장 관리**를 핵심으로 제공하며, 이를 통해 " +
+                                "**자주 안 입는 옷에 대해 대여 또는 판매를 추천**하여 옷의 활용도를 높입니다.\n\n" +
+                                "**주요 특징:**\n" +
+                                "1. **회원 기반 서비스:** 옷장 관리, 중고 거래는 회원 전용 기능입니다.\n" +
+                                "2. **비회원 접근:** 공개 옷장 및 중고 거래 게시물 조회는 비회원도 가능합니다.\n" +
+                                "3. **직거래 기반:** 모든 중고 거래는 사용자 간의 직거래를 기본으로 합니다.\n" +
+                                "4. **독립적 거래:** 옷장 서비스를 이용하지 않는 회원도 판매 및 구매 활동에 참여할 수 있습니다.\n\n" +
+                                "API는 인증, 옷장, 아이템, 중고 거래 게시물 등 모든 기능을 RESTful하게 제공합니다.")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/common/response/PageResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/response/PageResponse.java
@@ -2,7 +2,7 @@ package org.example.ootoutfitoftoday.common.response;
 
 import lombok.Builder;
 import org.example.ootoutfitoftoday.common.exception.SuccessCode;
-import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -10,13 +10,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record ApiSliceResponse<T>(
+public record PageResponse<T>(
         HttpStatus httpStatus,
         int statusValue,
         boolean success,
         String code,
         String message,
-        SliceData<T> data,
+        PageData<T> data,
         LocalDateTime timestamp
 ) {
 
@@ -24,24 +24,24 @@ public record ApiSliceResponse<T>(
      * 성공적인 요청에 대한 페이징 응답을 반환하는 메서드
      * 주어진 데이터를 포함하여 HTTP 상태 코드와 함께 응답을 반환
      *
-     * @param sliceData 요청 성공 시 반환할 페이징 데이터
-     * @return HTTP 상태코드 성공 응답과 함께 ApiSliceResponse<T>
+     * @param pagedData 요청 성공 시 반환할 페이징 데이터
+     * @return HTTP 상태코드 성공 응답과 함께 ApiPageResponse<T>
      */
-    public static <T> ResponseEntity<ApiSliceResponse<T>> success(Slice<T> sliceData, SuccessCode successCode) {
+    public static <T> ResponseEntity<PageResponse<T>> success(Page<T> pagedData, SuccessCode successCode) {
 
         return ResponseEntity.status(successCode.getHttpStatus()).body(
-                ApiSliceResponse.<T>builder()
+                PageResponse.<T>builder()
                         .httpStatus(successCode.getHttpStatus())
                         .statusValue(successCode.getHttpStatus().value())
                         .success(true)
                         .code(successCode.getCode())
                         .message(successCode.getMessage())
-                        .data(SliceData.<T>builder()
-                                .content(sliceData.getContent())
-                                .size(sliceData.getSize())
-                                .number(sliceData.getNumber())
-                                .hasNext(sliceData.hasNext())
-                                .hasPrevious(sliceData.hasPrevious())
+                        .data(PageData.<T>builder()
+                                .content(pagedData.getContent())
+                                .totalElements(pagedData.getTotalElements())
+                                .totalPages(pagedData.getTotalPages())
+                                .size(pagedData.getSize())
+                                .number(pagedData.getNumber())
                                 .build())
                         .timestamp(java.time.LocalDateTime.now())
                         .build()
@@ -49,12 +49,12 @@ public record ApiSliceResponse<T>(
     }
 
     @Builder
-    private record SliceData<T>(
+    private record PageData<T>(
             List<T> content,
+            long totalElements,
+            int totalPages,
             int size,
-            int number,
-            boolean hasNext,
-            boolean hasPrevious
+            int number
     ) {
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/common/response/Response.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/response/Response.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import java.time.LocalDateTime;
 
 @Builder
-public record ApiResponse<T>(
+public record Response<T>(
         HttpStatus httpStatus,
         int statusValue,
         boolean success,
@@ -26,10 +26,10 @@ public record ApiResponse<T>(
      * @param data 요청 성공 시 반환할 데이터
      * @return HTTP 상태코드 성공 응답과 함께 성공 데이터가 포함된 ApiResponseDto
      */
-    public static <T> ResponseEntity<ApiResponse<T>> success(T data, SuccessCode successCode) {
+    public static <T> ResponseEntity<Response<T>> success(T data, SuccessCode successCode) {
 
         return ResponseEntity.status(successCode.getHttpStatus()).body(
-                ApiResponse.<T>builder()
+                Response.<T>builder()
                         .httpStatus(successCode.getHttpStatus())
                         .statusValue(successCode.getHttpStatus().value())
                         .success(true)
@@ -48,10 +48,10 @@ public record ApiResponse<T>(
      * @return HTTP 에러 응답 코드와 함께 메시지가 포함된 ApiResponseDto
      */
     // 빌더를 통해서 생성하지 않은 필드는 null 값이 들어가는지 궁금
-    public static <T> ApiResponse<T> error(T data, ErrorCode errorCode) {
+    public static <T> Response<T> error(T data, ErrorCode errorCode) {
 
         return
-                ApiResponse.<T>builder()
+                Response.<T>builder()
                         .httpStatus(errorCode.getHttpStatus())
                         .statusValue(errorCode.getHttpStatus().value())
                         .success(false)

--- a/src/main/java/org/example/ootoutfitoftoday/common/response/SliceResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/response/SliceResponse.java
@@ -2,7 +2,7 @@ package org.example.ootoutfitoftoday.common.response;
 
 import lombok.Builder;
 import org.example.ootoutfitoftoday.common.exception.SuccessCode;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -10,13 +10,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record ApiPageResponse<T>(
+public record SliceResponse<T>(
         HttpStatus httpStatus,
         int statusValue,
         boolean success,
         String code,
         String message,
-        PageData<T> data,
+        SliceData<T> data,
         LocalDateTime timestamp
 ) {
 
@@ -24,24 +24,24 @@ public record ApiPageResponse<T>(
      * 성공적인 요청에 대한 페이징 응답을 반환하는 메서드
      * 주어진 데이터를 포함하여 HTTP 상태 코드와 함께 응답을 반환
      *
-     * @param pagedData 요청 성공 시 반환할 페이징 데이터
-     * @return HTTP 상태코드 성공 응답과 함께 ApiPageResponse<T>
+     * @param sliceData 요청 성공 시 반환할 페이징 데이터
+     * @return HTTP 상태코드 성공 응답과 함께 ApiSliceResponse<T>
      */
-    public static <T> ResponseEntity<ApiPageResponse<T>> success(Page<T> pagedData, SuccessCode successCode) {
+    public static <T> ResponseEntity<SliceResponse<T>> success(Slice<T> sliceData, SuccessCode successCode) {
 
         return ResponseEntity.status(successCode.getHttpStatus()).body(
-                ApiPageResponse.<T>builder()
+                SliceResponse.<T>builder()
                         .httpStatus(successCode.getHttpStatus())
                         .statusValue(successCode.getHttpStatus().value())
                         .success(true)
                         .code(successCode.getCode())
                         .message(successCode.getMessage())
-                        .data(PageData.<T>builder()
-                                .content(pagedData.getContent())
-                                .totalElements(pagedData.getTotalElements())
-                                .totalPages(pagedData.getTotalPages())
-                                .size(pagedData.getSize())
-                                .number(pagedData.getNumber())
+                        .data(SliceData.<T>builder()
+                                .content(sliceData.getContent())
+                                .size(sliceData.getSize())
+                                .number(sliceData.getNumber())
+                                .hasNext(sliceData.hasNext())
+                                .hasPrevious(sliceData.hasPrevious())
                                 .build())
                         .timestamp(java.time.LocalDateTime.now())
                         .build()
@@ -49,12 +49,12 @@ public record ApiPageResponse<T>(
     }
 
     @Builder
-    private record PageData<T>(
+    private record SliceData<T>(
             List<T> content,
-            long totalElements,
-            int totalPages,
             int size,
-            int number
+            int number,
+            boolean hasNext,
+            boolean hasPrevious
     ) {
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/auth/controller/AuthController.java
@@ -2,7 +2,7 @@ package org.example.ootoutfitoftoday.domain.auth.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.auth.dto.request.AuthLoginRequest;
 import org.example.ootoutfitoftoday.domain.auth.dto.request.AuthSignupRequest;
@@ -23,32 +23,32 @@ public class AuthController {
 
     // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<Void>> signup(
+    public ResponseEntity<Response<Void>> signup(
             @Valid @RequestBody AuthSignupRequest request
     ) {
         authCommandService.signup(request);
 
-        return ApiResponse.success(null, AuthSuccessCode.USER_SIGNUP);
+        return Response.success(null, AuthSuccessCode.USER_SIGNUP);
     }
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<AuthLoginResponse>> login(
+    public ResponseEntity<Response<AuthLoginResponse>> login(
             @Valid @RequestBody AuthLoginRequest request
     ) {
         AuthLoginResponse response = authCommandService.login(request);
 
-        return ApiResponse.success(response, AuthSuccessCode.USER_LOGIN);
+        return Response.success(response, AuthSuccessCode.USER_LOGIN);
     }
 
     // 회원탈퇴
     @DeleteMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Void>> withdraw(
+    public ResponseEntity<Response<Void>> withdraw(
             @Valid @RequestBody AuthWithdrawRequest request,
             @AuthenticationPrincipal AuthUser authUser
     ) {
         authCommandService.withdraw(request, authUser);
 
-        return ApiResponse.success(null, AuthSuccessCode.USER_WITHDRAW);
+        return Response.success(null, AuthSuccessCode.USER_WITHDRAW);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/category/controller/CategoryController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/category/controller/CategoryController.java
@@ -2,8 +2,8 @@ package org.example.ootoutfitoftoday.domain.category.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiPageResponse;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.PageResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.category.dto.request.CategoryRequest;
 import org.example.ootoutfitoftoday.domain.category.dto.response.CategoryResponse;
 import org.example.ootoutfitoftoday.domain.category.exception.CategorySuccessCode;
@@ -21,17 +21,17 @@ public class CategoryController {
     private final CategoryQueryService categoryQueryService;
 
     @PostMapping("/admin/v1/categories")
-    public ResponseEntity<ApiResponse<CategoryResponse>> create(
+    public ResponseEntity<Response<CategoryResponse>> create(
             @Valid @RequestBody CategoryRequest categoryRequest
     ) {
 
         CategoryResponse response = categoryCommandService.createCategory(categoryRequest);
 
-        return ApiResponse.success(response, CategorySuccessCode.CATEGORY_CREATED);
+        return Response.success(response, CategorySuccessCode.CATEGORY_CREATED);
     }
 
     @GetMapping("/v1/categories")
-    public ResponseEntity<ApiPageResponse<CategoryResponse>> getAllCategories(
+    public ResponseEntity<PageResponse<CategoryResponse>> getAllCategories(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "createdAt") String sort,
@@ -45,27 +45,27 @@ public class CategoryController {
                 direction
         );
 
-        return ApiPageResponse.success(categories, CategorySuccessCode.CATEGORY_OK);
+        return PageResponse.success(categories, CategorySuccessCode.CATEGORY_OK);
     }
 
     @PutMapping("/admin/v1/categories/{categoryId}")
-    public ResponseEntity<ApiResponse<CategoryResponse>> updateCategory(
+    public ResponseEntity<Response<CategoryResponse>> updateCategory(
             @PathVariable Long categoryId,
             @Valid @RequestBody CategoryRequest categoryRequest
     ) {
 
         CategoryResponse categoryResponse = categoryCommandService.updateCategory(categoryId, categoryRequest);
 
-        return ApiResponse.success(categoryResponse, CategorySuccessCode.CATEGORY_UPDATE);
+        return Response.success(categoryResponse, CategorySuccessCode.CATEGORY_UPDATE);
     }
 
     @DeleteMapping("/admin/v1/categories/{categoryId}")
-    public ResponseEntity<ApiResponse<Void>> deleteCategory(
+    public ResponseEntity<Response<Void>> deleteCategory(
             @PathVariable Long categoryId
     ) {
 
         categoryCommandService.deleteCategory(categoryId);
 
-        return ApiResponse.success(null, CategorySuccessCode.CATEGORY_DELETE);
+        return Response.success(null, CategorySuccessCode.CATEGORY_DELETE);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chat/controller/ChatController.java
@@ -1,7 +1,7 @@
 package org.example.ootoutfitoftoday.domain.chat.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiSliceResponse;
+import org.example.ootoutfitoftoday.common.response.SliceResponse;
 import org.example.ootoutfitoftoday.domain.chat.dto.response.ChatResponse;
 import org.example.ootoutfitoftoday.domain.chat.exception.ChatSuccessCode;
 import org.example.ootoutfitoftoday.domain.chat.service.query.ChatQueryService;
@@ -28,7 +28,7 @@ public class ChatController {
      * @return 채팅 리스트
      */
     @GetMapping
-    public ResponseEntity<ApiSliceResponse<ChatResponse>> getChats(
+    public ResponseEntity<SliceResponse<ChatResponse>> getChats(
             @PathVariable Long chatroomId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
@@ -37,6 +37,6 @@ public class ChatController {
 
         Slice<ChatResponse> chatResponses = chatQueryService.getChats(chatroomId, pageable);
 
-        return ApiSliceResponse.success(chatResponses, ChatSuccessCode.RETRIEVED_CHATS);
+        return SliceResponse.success(chatResponses, ChatSuccessCode.RETRIEVED_CHATS);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/controller/ChatroomController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/chatroom/controller/ChatroomController.java
@@ -1,8 +1,8 @@
 package org.example.ootoutfitoftoday.domain.chatroom.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
-import org.example.ootoutfitoftoday.common.response.ApiSliceResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
+import org.example.ootoutfitoftoday.common.response.SliceResponse;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.chatroom.dto.request.ChatroomRequest;
 import org.example.ootoutfitoftoday.domain.chatroom.dto.response.ChatroomResponse;
@@ -32,7 +32,7 @@ public class ChatroomController {
      * @return 공통 응답만 반환
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<Void>> createChatroom(
+    public ResponseEntity<Response<Void>> createChatroom(
             @RequestBody ChatroomRequest chatroomRequest,
             @AuthenticationPrincipal AuthUser authUser
     ) {
@@ -40,7 +40,7 @@ public class ChatroomController {
 
         chatroomCommandService.createChatroom(chatroomRequest, userId);
 
-        return ApiResponse.success(null, ChatroomSuccessCode.CREATED_CHATROOM);
+        return Response.success(null, ChatroomSuccessCode.CREATED_CHATROOM);
     }
 
     /**
@@ -52,7 +52,7 @@ public class ChatroomController {
      * @return 채팅방 리스트
      */
     @GetMapping
-    public ResponseEntity<ApiSliceResponse<ChatroomResponse>> getChatrooms(
+    public ResponseEntity<SliceResponse<ChatroomResponse>> getChatrooms(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
@@ -63,7 +63,7 @@ public class ChatroomController {
 
         Slice<ChatroomResponse> chatroomResponses = chatroomQueryService.getChatrooms(userId, pageable);
 
-        return ApiSliceResponse.success(chatroomResponses, ChatroomSuccessCode.RETRIEVED_CHATROOMS);
+        return SliceResponse.success(chatroomResponses, ChatroomSuccessCode.RETRIEVED_CHATROOMS);
     }
 
     /**
@@ -74,13 +74,13 @@ public class ChatroomController {
      * @return 공통 응답만 반환
      */
     @DeleteMapping("/{chatroomId}")
-    public ResponseEntity<ApiResponse<Void>> deleteChatroom(
+    public ResponseEntity<Response<Void>> deleteChatroom(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long chatroomId
     ) {
         Long userId = authUser.getUserId();
         chatroomCommandService.deleteChatroom(chatroomId, userId);
 
-        return ApiResponse.success(null, ChatroomSuccessCode.DELETED_CHATROOM);
+        return Response.success(null, ChatroomSuccessCode.DELETED_CHATROOM);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
@@ -2,8 +2,8 @@ package org.example.ootoutfitoftoday.domain.closet.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiPageResponse;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.PageResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.closet.dto.request.ClosetSaveRequest;
 import org.example.ootoutfitoftoday.domain.closet.dto.request.ClosetUpdateRequest;
@@ -31,7 +31,7 @@ public class ClosetController {
      * @return ClosetSaveResponse: 등록된 옷장 정보와 성공 응답 코드
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<ClosetSaveResponse>> createCloset(
+    public ResponseEntity<Response<ClosetSaveResponse>> createCloset(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody ClosetSaveRequest closetSaveRequest
     ) {
@@ -40,7 +40,7 @@ public class ClosetController {
                 closetSaveRequest
         );
 
-        return ApiResponse.success(closetSaveResponse, ClosetSuccessCode.CLOSET_CREATED);
+        return Response.success(closetSaveResponse, ClosetSuccessCode.CLOSET_CREATED);
     }
 
     /**
@@ -53,7 +53,7 @@ public class ClosetController {
      * @return Page<ClosetGetPublicResponse>: 공개 옷장 리스트
      */
     @GetMapping("/public")
-    public ResponseEntity<ApiPageResponse<ClosetGetPublicResponse>> getPublicClosets(
+    public ResponseEntity<PageResponse<ClosetGetPublicResponse>> getPublicClosets(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "createdAt") String sort,
@@ -67,7 +67,7 @@ public class ClosetController {
                 direction
         );
 
-        return ApiPageResponse.success(closetGetPublicResponses, ClosetSuccessCode.CLOSETS_GET_PUBLIC_OK);
+        return PageResponse.success(closetGetPublicResponses, ClosetSuccessCode.CLOSETS_GET_PUBLIC_OK);
     }
 
     /**
@@ -78,12 +78,12 @@ public class ClosetController {
      * @throws ClosetException: 옷장이 존재하지 않거나 삭제된 경우 (CLOSET_NOT_FOUND)
      */
     @GetMapping("/{closetId}")
-    public ResponseEntity<ApiResponse<ClosetGetResponse>> getCloset(
+    public ResponseEntity<Response<ClosetGetResponse>> getCloset(
             @PathVariable Long closetId
     ) {
         ClosetGetResponse closetGetResponse = closetQueryService.getCloset(closetId);
 
-        return ApiResponse.success(closetGetResponse, ClosetSuccessCode.CLOSET_GET_OK);
+        return Response.success(closetGetResponse, ClosetSuccessCode.CLOSET_GET_OK);
     }
 
     /**
@@ -97,7 +97,7 @@ public class ClosetController {
      * @return Page<ClosetGetMyResponse>: 내 옷장 리스트
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiPageResponse<ClosetGetMyResponse>> getClosetByMe(
+    public ResponseEntity<PageResponse<ClosetGetMyResponse>> getClosetByMe(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -113,7 +113,7 @@ public class ClosetController {
                 direction
         );
 
-        return ApiPageResponse.success(closetGetMyResponses, ClosetSuccessCode.CLOSETS_GET_MY_OK);
+        return PageResponse.success(closetGetMyResponses, ClosetSuccessCode.CLOSETS_GET_MY_OK);
     }
 
     /**
@@ -125,7 +125,7 @@ public class ClosetController {
      * @return closetUpdateResponse: 수정된 옷장 정보와 성공 응답 코드
      */
     @PutMapping("/{closetId}")
-    public ResponseEntity<ApiResponse<ClosetUpdateResponse>> updateCloset(
+    public ResponseEntity<Response<ClosetUpdateResponse>> updateCloset(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long closetId,
             @Valid @RequestBody ClosetUpdateRequest closetUpdateRequest
@@ -137,7 +137,7 @@ public class ClosetController {
                 closetUpdateRequest
         );
 
-        return ApiResponse.success(closetUpdateResponse, ClosetSuccessCode.CLOSET_UPDATE_OK);
+        return Response.success(closetUpdateResponse, ClosetSuccessCode.CLOSET_UPDATE_OK);
     }
 
     /**
@@ -148,7 +148,7 @@ public class ClosetController {
      * @return ClosetDeleteResponse 삭제된 옷장 ID와 삭제 시간
      */
     @DeleteMapping("/{closetId}")
-    public ResponseEntity<ApiResponse<ClosetDeleteResponse>> deleteCloset(
+    public ResponseEntity<Response<ClosetDeleteResponse>> deleteCloset(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long closetId
     ) {
@@ -158,6 +158,6 @@ public class ClosetController {
                 closetId
         );
 
-        return ApiResponse.success(response, ClosetSuccessCode.CLOSET_DELETE_OK);
+        return Response.success(response, ClosetSuccessCode.CLOSET_DELETE_OK);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetclotheslink/controller/ClosetClothesLinkController.java
@@ -2,8 +2,8 @@ package org.example.ootoutfitoftoday.domain.closetclotheslink.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiPageResponse;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.PageResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.request.ClosetClothesLinkRequest;
 import org.example.ootoutfitoftoday.domain.closetclotheslink.dto.response.ClosetClothesLinkDeleteResponse;
@@ -34,7 +34,7 @@ public class ClosetClothesLinkController {
      * @return ClosetClothesLinkResponse 연결 정보
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<ClosetClothesLinkResponse>> createClosetClothesLink(
+    public ResponseEntity<Response<ClosetClothesLinkResponse>> createClosetClothesLink(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long closetId,
             @Valid @RequestBody ClosetClothesLinkRequest closetClothesLinkRequest
@@ -46,7 +46,7 @@ public class ClosetClothesLinkController {
                 closetClothesLinkRequest
         );
 
-        return ApiResponse.success(closetClothesLinkResponse, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_LINKED);
+        return Response.success(closetClothesLinkResponse, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_LINKED);
     }
 
     /**
@@ -61,7 +61,7 @@ public class ClosetClothesLinkController {
      * @return ApiPageResponse<ClothesInClosetResponse> 옷 목록
      */
     @GetMapping
-    public ResponseEntity<ApiPageResponse<ClosetClothesLinkGetResponse>> getClosetClothesLink(
+    public ResponseEntity<PageResponse<ClosetClothesLinkGetResponse>> getClosetClothesLink(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long closetId,
             @RequestParam(defaultValue = "0") int page,
@@ -79,12 +79,12 @@ public class ClosetClothesLinkController {
                 direction
         );
 
-        return ApiPageResponse.success(closetClothesLinkGetResponses, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_LIST_OK);
+        return PageResponse.success(closetClothesLinkGetResponses, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_LIST_OK);
     }
 
     // 옷장에서 옷 삭제
     @DeleteMapping("/{clothesId}")
-    public ResponseEntity<ApiResponse<ClosetClothesLinkDeleteResponse>> deleteClosetClothesLink(
+    public ResponseEntity<Response<ClosetClothesLinkDeleteResponse>> deleteClosetClothesLink(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long closetId,
             @PathVariable Long clothesId
@@ -96,6 +96,6 @@ public class ClosetClothesLinkController {
                 clothesId
         );
 
-        return ApiResponse.success(closetClothesLinkDeleteResponse, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_DELETED);
+        return Response.success(closetClothesLinkDeleteResponse, ClosetClothesLinkSuccessCode.CLOSET_CLOTHES_DELETED);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/controller/ClothesController.java
@@ -2,8 +2,8 @@ package org.example.ootoutfitoftoday.domain.clothes.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiPageResponse;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.PageResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.clothes.dto.request.ClothesRequest;
 import org.example.ootoutfitoftoday.domain.clothes.dto.response.ClothesResponse;
@@ -26,18 +26,18 @@ public class ClothesController {
     private final ClothesQueryService clothesQueryService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<ClothesResponse>> createClothes(
+    public ResponseEntity<Response<ClothesResponse>> createClothes(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody ClothesRequest clothesRequest
     ) {
 
         ClothesResponse clothesResponse = clothesCommandService.createClothes(authUser.getUserId(), clothesRequest);
 
-        return ApiResponse.success(clothesResponse, ClothesSuccessCode.CLOTHES_CREATED);
+        return Response.success(clothesResponse, ClothesSuccessCode.CLOTHES_CREATED);
     }
 
     @GetMapping
-    public ResponseEntity<ApiPageResponse<ClothesResponse>> getClothes(
+    public ResponseEntity<PageResponse<ClothesResponse>> getClothes(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) ClothesColor clothesColor,
@@ -59,22 +59,22 @@ public class ClothesController {
                 direction
         );
 
-        return ApiPageResponse.success(clothes, ClothesSuccessCode.CLOTHES_OK);
+        return PageResponse.success(clothes, ClothesSuccessCode.CLOTHES_OK);
     }
 
     @GetMapping("/{clothesId}")
-    public ResponseEntity<ApiResponse<ClothesResponse>> getClothesById(
+    public ResponseEntity<Response<ClothesResponse>> getClothesById(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long clothesId
     ) {
 
         ClothesResponse clothesResponse = clothesQueryService.getClothesById(authUser.getUserId(), clothesId);
 
-        return ApiResponse.success(clothesResponse, ClothesSuccessCode.CLOTHES_OK);
+        return Response.success(clothesResponse, ClothesSuccessCode.CLOTHES_OK);
     }
 
     @PutMapping("/{clothesId}")
-    public ResponseEntity<ApiResponse<ClothesResponse>> updateClothes(
+    public ResponseEntity<Response<ClothesResponse>> updateClothes(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long clothesId,
             @Valid @RequestBody ClothesRequest clothesRequest
@@ -82,16 +82,16 @@ public class ClothesController {
 
         ClothesResponse clothesResponse = clothesCommandService.updateClothes(authUser.getUserId(), clothesId, clothesRequest);
 
-        return ApiResponse.success(clothesResponse, ClothesSuccessCode.CLOTHES_UPDATE);
+        return Response.success(clothesResponse, ClothesSuccessCode.CLOTHES_UPDATE);
     }
 
     @DeleteMapping("/{clothesId}")
-    public ResponseEntity<ApiResponse<Void>> deleteClothes(
+    public ResponseEntity<Response<Void>> deleteClothes(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long clothesId
     ) {
         clothesCommandService.deleteClothes(authUser.getUserId(), clothesId);
 
-        return ApiResponse.success(null, ClothesSuccessCode.CLOTHES_DELETE);
+        return Response.success(null, ClothesSuccessCode.CLOTHES_DELETE);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/dashboard/controller/AdminDashboardController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/dashboard/controller/AdminDashboardController.java
@@ -1,7 +1,7 @@
 package org.example.ootoutfitoftoday.domain.dashboard.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.dashboard.dto.response.AdminClothesStatisticsResponse;
 import org.example.ootoutfitoftoday.domain.dashboard.dto.response.AdminSalePostStatisticsResponse;
 import org.example.ootoutfitoftoday.domain.dashboard.dto.response.AdminTopCategoryStatisticsResponse;
@@ -24,30 +24,30 @@ public class AdminDashboardController {
     private final AdminDashboardQueryService adminDashboardQueryService;
 
     @GetMapping("/users/statistics")
-    public ResponseEntity<ApiResponse<AdminUserStatisticsResponse>> adminUserStatistics(
+    public ResponseEntity<Response<AdminUserStatisticsResponse>> adminUserStatistics(
             @RequestParam(required = false) LocalDate baseDate
     ) {
 
-        return ApiResponse.success(adminDashboardQueryService.adminUserStatistics(baseDate), DashboardSuccessCode.DASHBOARD_ADMIN_USER_STATISTICS_OK);
+        return Response.success(adminDashboardQueryService.adminUserStatistics(baseDate), DashboardSuccessCode.DASHBOARD_ADMIN_USER_STATISTICS_OK);
     }
 
     @GetMapping("/clothes/statistics")
-    public ResponseEntity<ApiResponse<AdminClothesStatisticsResponse>> adminClothesStatistics() {
+    public ResponseEntity<Response<AdminClothesStatisticsResponse>> adminClothesStatistics() {
 
-        return ApiResponse.success(adminDashboardQueryService.adminClothesStatistics(), DashboardSuccessCode.DASHBOARD_ADMIN_CLOTHES_STATISTICS_OK);
+        return Response.success(adminDashboardQueryService.adminClothesStatistics(), DashboardSuccessCode.DASHBOARD_ADMIN_CLOTHES_STATISTICS_OK);
     }
 
     @GetMapping("/sale-posts/statistics")
-    public ResponseEntity<ApiResponse<AdminSalePostStatisticsResponse>> adminSalePostStatistics(
+    public ResponseEntity<Response<AdminSalePostStatisticsResponse>> adminSalePostStatistics(
             @RequestParam(required = false) LocalDate baseDate
     ) {
 
-        return ApiResponse.success(adminDashboardQueryService.adminSalePostStatistics(baseDate), DashboardSuccessCode.DASHBOARD_ADMIN_SALE_POST_STATISTICS_OK);
+        return Response.success(adminDashboardQueryService.adminSalePostStatistics(baseDate), DashboardSuccessCode.DASHBOARD_ADMIN_SALE_POST_STATISTICS_OK);
     }
 
     @GetMapping("/popular")
-    public ResponseEntity<ApiResponse<AdminTopCategoryStatisticsResponse>> adminTopCategoryStatistics() {
+    public ResponseEntity<Response<AdminTopCategoryStatisticsResponse>> adminTopCategoryStatistics() {
 
-        return ApiResponse.success(adminDashboardQueryService.adminTopCategoryStatistics(), DashboardSuccessCode.DASHBOARD_ADMIN_TOP10_CATEGORY_STATISTICS_OK);
+        return Response.success(adminDashboardQueryService.adminTopCategoryStatistics(), DashboardSuccessCode.DASHBOARD_ADMIN_TOP10_CATEGORY_STATISTICS_OK);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/controller/SalePostController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/controller/SalePostController.java
@@ -2,7 +2,7 @@ package org.example.ootoutfitoftoday.domain.salepost.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.salepost.dto.request.SalePostCreateRequest;
 import org.example.ootoutfitoftoday.domain.salepost.dto.request.SalePostUpdateRequest;
@@ -32,7 +32,7 @@ public class SalePostController {
     private final SalePostQueryService salePostQueryService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<SalePostCreateResponse>> createSalePost(
+    public ResponseEntity<Response<SalePostCreateResponse>> createSalePost(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody SalePostCreateRequest request
     ) {
@@ -42,19 +42,19 @@ public class SalePostController {
                 request.getImageUrls()
         );
 
-        return ApiResponse.success(response, SalePostSuccessCode.SALE_POST_CREATED);
+        return Response.success(response, SalePostSuccessCode.SALE_POST_CREATED);
     }
 
     @GetMapping("/{salePostId}")
-    public ResponseEntity<ApiResponse<SalePostDetailResponse>> getSalePostDetail(@PathVariable Long salePostId) {
+    public ResponseEntity<Response<SalePostDetailResponse>> getSalePostDetail(@PathVariable Long salePostId) {
 
         SalePostDetailResponse response = salePostQueryService.getSalePostDetail(salePostId);
 
-        return ApiResponse.success(response, SalePostSuccessCode.SALE_POST_RETRIEVED);
+        return Response.success(response, SalePostSuccessCode.SALE_POST_RETRIEVED);
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<Slice<SalePostListResponse>>> getSalePosts(
+    public ResponseEntity<Response<Slice<SalePostListResponse>>> getSalePosts(
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) SaleStatus status,
             @RequestParam(required = false) String keyword,
@@ -72,11 +72,11 @@ public class SalePostController {
                 pageable
         );
 
-        return ApiResponse.success(salePosts, SalePostSuccessCode.SALE_POSTS_RETRIEVED);
+        return Response.success(salePosts, SalePostSuccessCode.SALE_POSTS_RETRIEVED);
     }
 
     @PutMapping("/{salePostId}")
-    public ResponseEntity<ApiResponse<SalePostDetailResponse>> updateSalePost(
+    public ResponseEntity<Response<SalePostDetailResponse>> updateSalePost(
             @PathVariable Long salePostId,
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody SalePostUpdateRequest request
@@ -87,21 +87,21 @@ public class SalePostController {
                 request
         );
 
-        return ApiResponse.success(response, SalePostSuccessCode.SALE_POST_UPDATED);
+        return Response.success(response, SalePostSuccessCode.SALE_POST_UPDATED);
     }
 
     @DeleteMapping("/{salePostId}")
-    public ResponseEntity<ApiResponse<Void>> deleteSalePost(
+    public ResponseEntity<Response<Void>> deleteSalePost(
             @PathVariable Long salePostId,
             @AuthenticationPrincipal AuthUser authUser
     ) {
         salePostCommandService.deleteSalePost(salePostId, authUser.getUserId());
 
-        return ApiResponse.success(null,  SalePostSuccessCode.SALE_POST_DELETED);
+        return Response.success(null, SalePostSuccessCode.SALE_POST_DELETED);
     }
 
     @PatchMapping("/{salePostId}/status")
-    public ResponseEntity<ApiResponse<SalePostDetailResponse>> updateSaleStatus(
+    public ResponseEntity<Response<SalePostDetailResponse>> updateSaleStatus(
             @PathVariable Long salePostId,
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody SaleStatusUpdateRequest request
@@ -112,11 +112,11 @@ public class SalePostController {
                 request.getStatus()
         );
 
-        return ApiResponse.success(response, SalePostSuccessCode.SALE_POST_STATUS_UPDATED);
+        return Response.success(response, SalePostSuccessCode.SALE_POST_STATUS_UPDATED);
     }
 
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<Slice<SalePostSummaryResponse>>> getMySalePosts(
+    public ResponseEntity<Response<Slice<SalePostSummaryResponse>>> getMySalePosts(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(required = false) SaleStatus status,
             @RequestParam(defaultValue = "0") int page,
@@ -132,6 +132,6 @@ public class SalePostController {
                 pageable
         );
 
-        return ApiResponse.success(response, SalePostSuccessCode.SALE_POST_RETRIEVED);
+        return Response.success(response, SalePostSuccessCode.SALE_POST_RETRIEVED);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/user/controller/UserController.java
@@ -2,7 +2,7 @@ package org.example.ootoutfitoftoday.domain.user.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.ootoutfitoftoday.common.response.ApiResponse;
+import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.user.dto.request.UserPasswordVerificationRequest;
 import org.example.ootoutfitoftoday.domain.user.dto.request.UserUpdateInfoRequest;
@@ -24,32 +24,32 @@ public class UserController {
 
     // 회원정보 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<GetMyInfoResponse>> getMyInfo(@AuthenticationPrincipal AuthUser authUser) {
+    public ResponseEntity<Response<GetMyInfoResponse>> getMyInfo(@AuthenticationPrincipal AuthUser authUser) {
 
         GetMyInfoResponse response = userQueryService.getMyInfo(authUser.getUserId());
 
-        return ApiResponse.success(response, UserSuccessCode.GET_MY_INFO);
+        return Response.success(response, UserSuccessCode.GET_MY_INFO);
     }
 
     // 회원정보 수정 전 비밀번호 검증
     @PostMapping("/password-verification")
-    public ResponseEntity<ApiResponse<Void>> verifyPassword(
+    public ResponseEntity<Response<Void>> verifyPassword(
             @Valid @RequestBody UserPasswordVerificationRequest request,
             @AuthenticationPrincipal AuthUser authUser) {
 
         userQueryService.verifyPassword(request, authUser);
 
-        return ApiResponse.success(null, UserSuccessCode.PASSWORD_VERIFIED);
+        return Response.success(null, UserSuccessCode.PASSWORD_VERIFIED);
     }
 
     // 회원정보 수정
     @PatchMapping
-    public ResponseEntity<ApiResponse<GetMyInfoResponse>> updateUserInfo(
+    public ResponseEntity<Response<GetMyInfoResponse>> updateUserInfo(
             @Valid @RequestBody UserUpdateInfoRequest request,
             @AuthenticationPrincipal AuthUser authUser
     ) {
 
         GetMyInfoResponse response = userCommandService.updateMyInfo(request, authUser);
-        return ApiResponse.success(response, UserSuccessCode.UPDATE_MY_INFO);
+        return Response.success(response, UserSuccessCode.UPDATE_MY_INFO);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/ootoutfitoftoday/security/config/SecurityConfig.java
@@ -48,6 +48,9 @@ public class SecurityConfig {
                 .rememberMe(AbstractHttpConfigurer::disable)     // 서버가 쿠키 발급하여 자동 로그인
 
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET,
+                                "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()       //Swagger API 문서 관련 경로 허용 (인증 없이 접근 가능)
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()                    // Actuator Health Check 경로 허용 (EC2 배포 환경 체크용)
                         .requestMatchers(HttpMethod.POST, "/v1/auth/signup", "/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/v1/closets/public",


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #142

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- API 명세 자동화 및 개발 단계에서의 테스트 편의성 증대를 위해 Springdoc OpenAPI (Swagger 3)를 프로젝트에 도입
-Swagger 설정 추가
   - build.gradle에 springdoc-openapi-starter-webmvc-ui 의존성 추가
   - SwaggerConfig.java 생성 및 OpenAPI Bean 정의
   - API 제목과 설명을 "디지털 옷장 기반 중고 거래 플랫폼" 특징을 강조하여 설정 완료
   - SecurityConfig.java에서 Swagger UI 및 API Docs 경로를 permitAll()로 설정하여 인증 없이 접근 가능하도록 처리
- Swagger의 @ApiResponse 어노테이션과의 충돌을 방지하기 위해 사용하던 공통 응답 클래스들의 이름(ApiResponse, ApiPageResponse 등)에서 Api Prefix를 제거하는 리팩터링을 함께 진행

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가 (Swagger UI / API 문서화)
- [x] 코드 리팩토링 (공통 응답 클래스 리네임)
- [x] 빌드/인프라 부분 수정 (Gradle 의존성 추가)
- [x] 파일 혹은 폴더 추가 (SwaggerConfig.java)
- [x] 설정 수정 (SecurityConfig)

## 📸스크린샷 
- Swagger API 문서 확인
<img width="1470" height="414" alt="스크린샷 2025-10-24 11 23 27" src="https://github.com/user-attachments/assets/3b5e8ee0-b403-4c9d-af6d-c7d8a4681838" />


## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 공통 응답 클래스가 리네임되었으므로, 기존 코드에서 해당 클래스들을 사용하던 모든 부분이 새로운 이름으로 변경되었는지 (IDE의 Refactor Rename 기능이 정상 작동했는지) 한번 더 검토 부탁드립니다.

- 이후 API 컨트롤러 개발 시, Response 클래스와 Swagger의 @ApiResponse 사용에 충돌이 없을 것입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
