### PR TITLE
[ci] Docker 이미지 태그 소문자 강제 적용

### DIFF
--- a/scripts/ecr-push.sh
+++ b/scripts/ecr-push.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 : "${IMAGE_TAG:?IMAGE_TAG required}"
 
 # ECR 저장소 이름과 태그는 소문자여야 하므로, 변환을 강제합니다.
-ECR_REPO=$(echo "${ECR_REPO}" | tr '[:upper:]' '[:lower:]')
-IMAGE_TAG=$(echo "${IMAGE_TAG}" | tr '[:upper:]' '[:lower:]')
+EECR_REPO=${ECR_REPO,,}
+IMAGE_TAG=${IMAGE_TAG,,}
 
 REG_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 FULL_URI="${REG_URI}/${ECR_REPO}:${IMAGE_TAG}"

--- a/scripts/ecr-push.sh
+++ b/scripts/ecr-push.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 : "${ECR_REPO:?ECR_REPO required}"
 : "${IMAGE_TAG:?IMAGE_TAG required}"
 
+# ECR 저장소 이름과 태그는 소문자여야 하므로, 변환을 강제합니다.
+ECR_REPO=$(echo "${ECR_REPO}" | tr '[:upper:]' '[:lower:]')
+IMAGE_TAG=$(echo "${IMAGE_TAG}" | tr '[:upper:]' '[:lower:]')
+
 REG_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 FULL_URI="${REG_URI}/${ECR_REPO}:${IMAGE_TAG}"
 
@@ -15,9 +19,11 @@ aws ecr get-login-password --region "${AWS_REGION}" \
   | docker login --username AWS --password-stdin "${REG_URI}"
 
 echo "[ECR] Build ${ECR_REPO}:${IMAGE_TAG}"
+# 수정된 소문자 변수 사용
 docker build -t "${ECR_REPO}:${IMAGE_TAG}" .
 
 echo "[ECR] Tag -> ${FULL_URI}"
+# 수정된 소문자 변수 사용
 docker tag "${ECR_REPO}:${IMAGE_TAG}" "${FULL_URI}"
 
 echo "[ECR] Push -> ${FULL_URI}"


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #167 

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- CI 파이프라인의 ECR Build & Push 단계에서 발생했던 repository name must be lowercase 에러를 해결
- ecr-push.sh 스크립트에 쉘 명령어(tr)를 추가하여, 이미지 태그와 저장소 이름으로 사용되는 환경 변수를 Docker 명령 실행 전에 모두 소문자로 강제 변환하도록 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정 (ECR 빌드 실패 수정)
- [x] 코드 리팩토링 (쉘 스크립트 로직 개선)
- [x] 빌드/인프라 부분 수정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.