### PR TITLE
[ci] 이미지 태그 소문자 변환 로직의 변수 참조 오류 수정

### DIFF
--- a/scripts/ecr-push.sh
+++ b/scripts/ecr-push.sh
@@ -7,8 +7,9 @@ set -euo pipefail
 : "${ECR_REPO:?ECR_REPO required}"
 : "${IMAGE_TAG:?IMAGE_TAG required}"
 
-# ECR 저장소 이름과 태그는 소문자여야 하므로, 변환을 강제합니다.
-EECR_REPO=${ECR_REPO,,}
+# ECR 저장소 이름과 태그는 소문자여야 하므로, Bash 파라미터 확장을 사용해 강제 변환합니다.
+# 이 로직은 불필요한 서브쉘 생성 없이 변수를 효율적으로 변환합니다.
+ECR_REPO=${ECR_REPO,,}
 IMAGE_TAG=${IMAGE_TAG,,}
 
 REG_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
@@ -19,11 +20,10 @@ aws ecr get-login-password --region "${AWS_REGION}" \
   | docker login --username AWS --password-stdin "${REG_URI}"
 
 echo "[ECR] Build ${ECR_REPO}:${IMAGE_TAG}"
-# 수정된 소문자 변수 사용
+# 이제 ECR_REPO와 IMAGE_TAG는 소문자 값을 가집니다.
 docker build -t "${ECR_REPO}:${IMAGE_TAG}" .
 
 echo "[ECR] Tag -> ${FULL_URI}"
-# 수정된 소문자 변수 사용
 docker tag "${ECR_REPO}:${IMAGE_TAG}" "${FULL_URI}"
 
 echo "[ECR] Push -> ${FULL_URI}"


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #169 

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- ECR 이미지 태그 및 저장소 이름 소문자 변환 로직의 내부 참조 오류를 수정하여 빌드 실패를 최종적으로 해결함
- ./scripts/ecr-push.sh` 파일에서 `ECR_REPO`와 `IMAGE_TAG` 변수가 변환된 소문자 값으로 정확하게 덮어씌워지도록 로직을 확정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정 (ECR 빌드 실패 수정)
- [x] 코드 리팩토링 (쉘 스크립트 변수 할당 로직 개선)
- [x] 빌드/인프라 부분 수정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.