### PR TITLE
[feat] API 명세 Swagger 어노테이션 적용 

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
@@ -1,5 +1,9 @@
 package org.example.ootoutfitoftoday.domain.closet.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.ootoutfitoftoday.common.response.PageResponse;
@@ -16,6 +20,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "옷장 관리", description = "옷장관련 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/closets")
@@ -30,6 +36,16 @@ public class ClosetController {
      * @param closetSaveRequest: 옷장 등록 요청 객체 (이름, 설명 등 포함)
      * @return ClosetSaveResponse: 등록된 옷장 정보와 성공 응답 코드
      */
+    @Operation(
+            summary = "옷장 등록",
+            description = "회원이 자신의 옷장을 등록합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "등록 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패")
+            }
+    )
     @PostMapping
     public ResponseEntity<Response<ClosetSaveResponse>> createCloset(
             @AuthenticationPrincipal AuthUser authUser,
@@ -52,6 +68,13 @@ public class ClosetController {
      * @param direction: 정렬 방향
      * @return Page<ClosetGetPublicResponse>: 공개 옷장 리스트
      */
+    @Operation(
+            summary = "공개 옷장 전체 조회",
+            description = "공개 옷장 전체를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공")
+            }
+    )
     @GetMapping("/public")
     public ResponseEntity<PageResponse<ClosetGetPublicResponse>> getPublicClosets(
             @RequestParam(defaultValue = "0") int page,
@@ -77,6 +100,16 @@ public class ClosetController {
      * @return ClosetGetResponse: 옷장 상세 정보 DTO
      * @throws ClosetException: 옷장이 존재하지 않거나 삭제된 경우 (CLOSET_NOT_FOUND)
      */
+    @Operation(
+            summary = "옷장 상세 조회",
+            description = "회원이 옷장의 상세 정보를 조회합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "404", description = "옷장을 찾을 수 없음")
+            }
+    )
     @GetMapping("/{closetId}")
     public ResponseEntity<Response<ClosetGetResponse>> getCloset(
             @PathVariable Long closetId
@@ -96,6 +129,15 @@ public class ClosetController {
      * @param direction: 정렬 방향
      * @return Page<ClosetGetMyResponse>: 내 옷장 리스트
      */
+    @Operation(
+            summary = "내 옷장 전체 조회",
+            description = "회원이 자신의 전체 옷장을 조회합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패")
+            }
+    )
     @GetMapping("/me")
     public ResponseEntity<PageResponse<ClosetGetMyResponse>> getClosetByMe(
             @AuthenticationPrincipal AuthUser authUser,
@@ -124,6 +166,18 @@ public class ClosetController {
      * @param closetUpdateRequest: 옷장 수정 요청 객체 (이름, 설명 등 포함)
      * @return closetUpdateResponse: 수정된 옷장 정보와 성공 응답 코드
      */
+    @Operation(
+            summary = "내 옷장 정보 수정",
+            description = "회원이 자신의 옷장 정보를 수정합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "수정 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "403", description = "권한 없음"),
+                    @ApiResponse(responseCode = "404", description = "옷장을 찾을 수 없음")
+            }
+    )
     @PutMapping("/{closetId}")
     public ResponseEntity<Response<ClosetUpdateResponse>> updateCloset(
             @AuthenticationPrincipal AuthUser authUser,
@@ -147,6 +201,17 @@ public class ClosetController {
      * @param closetId: 삭제할 옷장의 ID
      * @return ClosetDeleteResponse 삭제된 옷장 ID와 삭제 시간
      */
+    @Operation(
+            summary = "내 옷장 삭제",
+            description = "회원이 자신의 옷장을 삭제합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "삭제 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "403", description = "권한 없음"),
+                    @ApiResponse(responseCode = "404", description = "옷장을 찾을 수 없음")
+            }
+    )
     @DeleteMapping("/{closetId}")
     public ResponseEntity<Response<ClosetDeleteResponse>> deleteCloset(
             @AuthenticationPrincipal AuthUser authUser,

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/controller/ClosetController.java
@@ -21,7 +21,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "옷장 관리", description = "옷장관련 API")
-@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/closets")

--- a/src/main/java/org/example/ootoutfitoftoday/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/ootoutfitoftoday/security/config/SecurityConfig.java
@@ -48,20 +48,36 @@ public class SecurityConfig {
                 .rememberMe(AbstractHttpConfigurer::disable)     // 서버가 쿠키 발급하여 자동 로그인
 
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET,
-                                "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()       //Swagger API 문서 관련 경로 허용 (인증 없이 접근 가능)
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()                    // Actuator Health Check 경로 허용 (EC2 배포 환경 체크용)
+                        // Swagger 관련 경로 - 모든 HTTP 메서드 허용
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
+
+                        // Actuator Health Check
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+
+                        // 인증 없이 접근 가능한 API
                         .requestMatchers(HttpMethod.POST, "/v1/auth/signup", "/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/v1/closets/public",
+                                "/v1/closets/{closetId}",  // 추가 추천
                                 "/v1/sale-posts",
                                 "/v1/sale-posts/{salePostId}",
-                                "/v1/categories",
-                                "/ws/**").permitAll()
+                                "/v1/categories").permitAll()
+
+                        // WebSocket
+                        .requestMatchers("/ws/**").permitAll()
+
+                        // Admin
                         .requestMatchers("/admin/**").hasAuthority(UserRole.Authority.ADMIN)
-                        .anyRequest().authenticated() // 다른 요청들은 authentication 필요
+
+                        // 나머지는 인증 필요
+                        .anyRequest().authenticated()
                 )
                 .build();
     }
 }
-


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #143 

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- ClosetController에 OpenAPI (Swagger) 어노테이션을 적용하여 API 명세를 구축 
- Spring Security 설정에서 Swagger 관련 경로를 인증 예외 처리하여 개발 및 테스트 시 문서 접근성을 확보

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="1680" height="1050" alt="스크린샷 2025-10-26 00 08 06" src="https://github.com/user-attachments/assets/262915b8-acd1-4463-8616-efca9bc3adfa" />


## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- Spring Security에 Swagger/OpenAPI 경로 인증 제외 추가
   - Spring Security 설정 파일에 다음 경로들을 permitAll()로 설정하여 인증 없이 접근할 수 있도록 허용

```
.requestMatchers(
    "/swagger-ui/**",
    "/v3/api-docs/**",
    "/v3/api-docs.yaml",
    "/swagger-resources/**",
    "/webjars/**"
).permitAll()
```
효과: 개발 환경에서 Swagger UI 접근 시 로그인 등의 인증 절차를 생략하여 편의성을 높임

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
