### PR TITLE
[feat] 이미지 메타데이터 저장 API 구현 

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/controller/ImageController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/controller/ImageController.java
@@ -8,7 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
+import org.example.ootoutfitoftoday.domain.image.dto.request.ImageSaveRequest;
 import org.example.ootoutfitoftoday.domain.image.dto.request.PresignedUrlRequest;
+import org.example.ootoutfitoftoday.domain.image.dto.response.ImageSaveResponse;
 import org.example.ootoutfitoftoday.domain.image.dto.response.PresignedUrlResponse;
 import org.example.ootoutfitoftoday.domain.image.exception.ImageSuccessCode;
 import org.example.ootoutfitoftoday.domain.image.service.command.ImageCommandService;
@@ -58,5 +60,32 @@ public class ImageController {
         );
 
         return Response.success(response, ImageSuccessCode.PRESIGNED_URL_CREATED);
+    }
+
+    /**
+     * 이미지 메타데이터 저장 API
+     *
+     * @param request 이미지 저장 요청 객체 (이미지 경로, 타입 등 포함)
+     * @return ImageSaveResponse 객체를 포함한 성공 응답
+     */
+    @Operation(
+            summary = "이미지 메타데이터 저장",
+            description = "S3에 업로드된 이미지의 메타데이터를 DB에 저장합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "저장 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "409", description = "이미지가 이미 존재함")
+            }
+    )
+    @PostMapping
+    public ResponseEntity<Response<ImageSaveResponse>> saveImage(
+            @Valid @RequestBody ImageSaveRequest request
+    ) {
+
+        ImageSaveResponse response = imageCommandService.saveImage(request);
+
+        return Response.success(response, ImageSuccessCode.IMAGE_SAVED);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/dto/request/ImageSaveRequest.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/dto/request/ImageSaveRequest.java
@@ -1,0 +1,32 @@
+package org.example.ootoutfitoftoday.domain.image.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+// 이미지 메타데이터 저장 요청 DTO
+public record ImageSaveRequest(
+
+        @NotBlank(message = "파일명은 필수입니다.")
+        String fileName,
+
+        @NotBlank(message = "URL은 필수입니다.")
+        String url,
+
+        @NotBlank(message = "S3 Key는 필수입니다.")
+        String s3Key,
+
+        @NotBlank(message = "Content Type은 필수입니다.")
+        String contentType,
+
+        @NotBlank(message = "이미지 타입은 필수입니다.")
+        @Pattern(regexp = "^(CLOSET|CLOTHES|SALEPOST|USER)$",
+                message = "이미지 타입은 CLOSET, CLOTHES, SALEPOST, USER 중 하나여야 합니다.")
+        String type,
+
+        @NotNull(message = "파일 크기는 필수입니다.")
+        @Min(value = 1, message = "파일 크기는 1바이트 이상이어야 합니다.")
+        Long size
+) {
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/dto/response/ImageSaveResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/dto/response/ImageSaveResponse.java
@@ -1,0 +1,33 @@
+package org.example.ootoutfitoftoday.domain.image.dto.response;
+
+import org.example.ootoutfitoftoday.domain.image.entity.Image;
+
+import java.time.LocalDateTime;
+
+// 이미지 메타데이터 저장 응답 DTO
+public record ImageSaveResponse(
+        Long id,
+        String fileName,
+        String url,
+        String s3Key,
+        String contentType,
+        String type,
+        Long size,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ImageSaveResponse from(Image image) {
+
+        return new ImageSaveResponse(
+                image.getId(),
+                image.getFileName(),
+                image.getUrl(),
+                image.getS3Key(),
+                image.getContentType(),
+                image.getType().name(),
+                image.getSize(),
+                image.getCreatedAt(),
+                image.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/entity/Image.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/entity/Image.java
@@ -23,6 +23,9 @@ public class Image extends BaseEntity {
     @Column(length = 255, nullable = false)
     private String fileName;
 
+    @Column(length = 1000, nullable = false)
+    private String s3Key;
+
     @Column(length = 100, nullable = false)
     private String contentType;
 
@@ -30,21 +33,42 @@ public class Image extends BaseEntity {
     private Long size;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private ImageType type;
 
     @Builder(access = AccessLevel.PROTECTED)
     public Image(
             String url,
             String fileName,
+            String s3Key,
             String contentType,
             Long size,
             ImageType type
     ) {
         this.url = url;
         this.fileName = fileName;
+        this.s3Key = s3Key;
         this.contentType = contentType;
         this.size = size;
         this.type = type;
+    }
+
+    // 정적 팩토리 메서드
+    public static Image create(
+            String url,
+            String fileName,
+            String s3Key,
+            String contentType,
+            Long size,
+            ImageType type
+    ) {
+        return Image.builder()
+                .url(url)
+                .fileName(fileName)
+                .s3Key(s3Key)
+                .contentType(contentType)
+                .size(size)
+                .type(type)
+                .build();
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/exception/ImageErrorCode.java
@@ -13,7 +13,9 @@ public enum ImageErrorCode implements ErrorCode {
     INVALID_FILE_EXTENSION("INVALID_FILE_EXTENSION", HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     INVALID_IMAGE_TYPE("INVALID_IMAGE_TYPE", HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 타입입니다."),
     FILE_SIZE_EXCEEDED("FILE_SIZE_EXCEEDED", HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다."),
-    PRESIGNED_URL_GENERATION_FAILED("PRESIGNED_URL_GENERATION_FAILED", HttpStatus.INTERNAL_SERVER_ERROR, "Presigned URL 생성에 실패했습니다.");
+    PRESIGNED_URL_GENERATION_FAILED("PRESIGNED_URL_GENERATION_FAILED", HttpStatus.INTERNAL_SERVER_ERROR, "Presigned URL 생성에 실패했습니다."),
+    IMAGE_NOT_FOUND("IMAGE_NOT_FOUND", HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
+    IMAGE_ALREADY_EXISTS("IMAGE_ALREADY_EXISTS", HttpStatus.CONFLICT, "이미지가 이미 존재합니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/exception/ImageSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/exception/ImageSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ImageSuccessCode implements SuccessCode {
 
-    PRESIGNED_URL_CREATED("PRESIGNED_URL_CREATED", HttpStatus.OK, "Presigned URL이 생성되었습니다.");
+    PRESIGNED_URL_CREATED("PRESIGNED_URL_CREATED", HttpStatus.OK, "Presigned URL이 생성되었습니다."),
+    IMAGE_SAVED("IMAGE_SAVED", HttpStatus.CREATED, "이미지가 저장되었습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/repository/ImageRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/repository/ImageRepository.java
@@ -3,5 +3,13 @@ package org.example.ootoutfitoftoday.domain.image.repository;
 import org.example.ootoutfitoftoday.domain.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    // 삭제되지 않은 이미지 조회
+    Optional<Image> findByIdAndIsDeletedFalse(Long id);
+
+    // S3 Key로 이미지 조회
+    Optional<Image> findByS3KeyAndIsDeletedFalse(String s3Key);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/image/service/command/ImageCommandService.java
@@ -1,6 +1,8 @@
 package org.example.ootoutfitoftoday.domain.image.service.command;
 
+import org.example.ootoutfitoftoday.domain.image.dto.request.ImageSaveRequest;
 import org.example.ootoutfitoftoday.domain.image.dto.request.PresignedUrlRequest;
+import org.example.ootoutfitoftoday.domain.image.dto.response.ImageSaveResponse;
 import org.example.ootoutfitoftoday.domain.image.dto.response.PresignedUrlResponse;
 
 public interface ImageCommandService {
@@ -10,4 +12,7 @@ public interface ImageCommandService {
             Long userId,
             PresignedUrlRequest request
     );
+
+    // 이미지 메타데이터 저장
+    ImageSaveResponse saveImage(ImageSaveRequest request);
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #130 
- Presigned URL을 통해 S3에 업로드된 이미지의 메타데이터를 DB에 저장하는 API를 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 이미지 메타데이터 DB 저장
- S3 Key 중복 체크
- 이미지 타입별 분류 (CLOSET, CLOTHES, SALEPOST, USER)
- Soft Delete 지원

- 설계 결정:
   - userId 필드 제외: 연관관계(ClosetImage, ClothesImage)를 통해 소유자 추적
   - Image 엔티티는 순수 파일 정보만 관리
   
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
- 200 CREATED
<img width="1416" height="662" alt="스크린샷 2025-10-27 08 27 24" src="https://github.com/user-attachments/assets/c2e8c991-9a6d-4563-8ae1-926920eca7e0" />

- 400 에러
<img width="1413" height="466" alt="스크린샷 2025-10-27 08 31 27" src="https://github.com/user-attachments/assets/99fac8b9-77f4-4f77-b92f-e0f73a7050fb" />

- 403 에러
<img width="1411" height="291" alt="스크린샷 2025-10-27 08 29 11" src="https://github.com/user-attachments/assets/96e97c70-33b5-41b2-aef6-88cfa715c5ef" />

- 409 에러
<img width="1416" height="449" alt="스크린샷 2025-10-27 08 30 43" src="https://github.com/user-attachments/assets/ebd4e0ab-6edb-4b87-9cd2-6f5923bd6ee0" />


# 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

1. **userId 제외 결정**
   - Image 엔티티에 userId를 포함하지 않음
   - 소유자는 ClosetImage, ClothesImage 중간 테이블로 추적
   - Image는 순수 파일 정보만 관리
   - 이 설계가 적절한지 의견 부탁드립니다.

2. **S3 Key 중복 체크**
   - 같은 s3Key로 중복 저장 방지
   - 409 Conflict 에러 반환
   - 충분한 검증인지 의견 부탁드립니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
