### PR TITLE
[refactor] 카테고리 수정 API 쿼리 성능 개선

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/category/exception/CategoryErrorCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/category/exception/CategoryErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum CategoryErrorCode implements ErrorCode {
 
     CATEGORY_NOT_FOUND("CATEGORY_NOT_FOUND", HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
-    CANNOT_SET_SELF_AS_PARENT("CANNOT_SET_SELF_AS_PARENT", HttpStatus.BAD_REQUEST, "상위 카테고리를 자기 자신으로 설정할 수 없습니다.");
+    CANNOT_SET_SELF_AS_PARENT("CANNOT_SET_SELF_AS_PARENT", HttpStatus.BAD_REQUEST, "상위 카테고리를 자기 자신으로 설정할 수 없습니다."),
+    CATEGORY_CIRCULAR_REFERENCE("CATEGORY_CIRCULAR_REFERENCE", HttpStatus.BAD_REQUEST, "하위 카테고리를 자신의 상위 카테고리로 설정할 수 없습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/category/service/command/CategoryCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/category/service/command/CategoryCommandServiceImpl.java
@@ -221,7 +221,7 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
          *  - 추가로 사용자가 아이디의 값을 0 이하로 입력시 아이디의 값이 null로 처리되어 최상위 카테고리로 인식한다.
          */
         if (categoryRequest.getParentId() != null && categoryRequest.getParentId() > 0) {
-            parent = categoryRepository.findById(categoryRequest.getParentId())
+            parent = categoryRepository.findByIdAndIsDeletedFalse(categoryRequest.getParentId())
                     .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND)
                     );
         }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/category/service/command/CategoryCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/category/service/command/CategoryCommandServiceImpl.java
@@ -232,45 +232,63 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
         return CategoryResponse.from(category);
     }
 
-    // Todo: BFS 탐색용 큐를 활용하여 구현할 수도 있다. 이건 추후에 공부하고 적용하기!
     @Override
     public CategoryResponse updateCategory(Long id, CategoryRequest categoryRequest) {
 
+        // 수정할 카테고리가 존재하는 지 검증
         Category category = categoryRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND)
                 );
 
-        Category parent = null;
+        // 새로 설정할 부모 카테고리를 검증하고 조회
+        Category parent = validateCategory(id, categoryRequest.getParentId());
 
-        if (categoryRequest.getParentId() != null && categoryRequest.getParentId() > 0) {
-
-            parent = categoryRepository.findByIdAndIsDeletedFalse(categoryRequest.getParentId())
-                    .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND)
-                    );
-
-            /**
-             * 순환 참조 방지 코드
-             * 만약 parent가 category 자신의 하위카테고리거나 본인이라면, 자식을 상위 또는 자신을 상위 카테고리로 설정하는 것이다.
-             * 그래서 순환 참조가 발생할 수 있다.
-             * if(Objects.equals(current.getId(), category.getId())
-             * 관리자가 입력한 카테고리 아이디와 url에 입력된 아이디의 값을 비교 같다면 예외 처리
-             * current = current.getParent()로 상위 카테고리의 상위 카테고리까지 계속 올라가며 확인
-             */
-            Category current = parent;
-
-            while (current != null) {
-
-                if (Objects.equals(current.getId(), category.getId())) {
-                    throw new CategoryException(CategoryErrorCode.CANNOT_SET_SELF_AS_PARENT);
-                }
-
-                current = current.getParent();
-            }
-        }
-
+        // 카테고리명과 새로 설정할 상위 카테고리로 데이터 수정
         category.update(categoryRequest.getName(), parent);
 
         return CategoryResponse.from(category);
+    }
+
+    // 부모 카테고리 검증 로직
+    private Category validateCategory(Long categoryId, Long parentId) {
+
+        // 상위 카테고리가 null 이거나 0 이하면 최상위 카테고리
+        if (parentId == null || parentId <= 0) {
+
+            return null;
+        }
+
+        // 자기 자신을 부모로 설정할 경우
+        if (Objects.equals(categoryId, parentId)) {
+            throw new CategoryException(CategoryErrorCode.CANNOT_SET_SELF_AS_PARENT);
+        }
+
+        // 부모 카테고리 조회 (설정하려고 하는 상위 카테고리가 존재하는 지 검증)
+        Category parent = categoryRepository.findByIdAndIsDeletedFalse(parentId)
+                .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        // 순환 참조 검증
+        validateCircularReference(categoryId, parent);
+
+        return parent;
+    }
+
+    // 순환 참조 검증 로직 (categoryId: 수정하려고 하는 카테고리 아이디, parent: 새로 지정하려는 상위 카테고리 객체)
+    private void validateCircularReference(Long categoryId, Category parent) {
+
+        // 이미 위에서 수정할 카테고리 아이디와 상위의 아이디 값이 같은 지 검증했음. 그래서 parent의 상위부터 탐색 시작
+        Category current = parent.getParent();
+
+        // 최상위 카테고리까지 반복 (상향 탐색 방식)
+        while (current != null) {
+
+            // current의 상위들 중에 자신이 있다면 예외
+            if (Objects.equals(current.getId(), categoryId)) {
+                throw new CategoryException(CategoryErrorCode.CATEGORY_CIRCULAR_REFERENCE);
+            }
+
+            current = current.getParent();
+        }
     }
 
     @Override


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #196 

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 개선 전
    - 쿼리 두번 발생 (parent가 null이 아니라면 항상 두 번 조회)
    - 추후 고려해볼 사항
        - 현재 코드는 아래에서 상향 탐색 방식
        **Upward Traversal:** O(n) n은 트리의 높이에 따라 다르다
        - BFS 방식으로 개선할 시 하향 탐색 방식
        **Downward Traversal:** O(n) n은 트리의 높이에 따라 다르다
            - 둘의 차이는 트리 구조가 깊고, 순환 가능성이 하위에서 발생할 때
            - 내가 내 자식 중 하나를 상위로 설정하려는 경우을 막을 때 유용
    
    ```sql
    Category category = categoryRepository.findByIdAndIsDeletedFalse(id);
    Category parent = categoryRepository.findByIdAndIsDeletedFalse(categoryRequest.getParentId());
    ```
    

```sql
Hibernate: 
    select
        c1_0.id,
        c1_0.created_at,
        c1_0.deleted_at,
        c1_0.is_deleted,
        c1_0.name,
        c1_0.parent_id,
        c1_0.updated_at 
    from
        categories c1_0 
    where
        c1_0.id=? 
        and not(c1_0.is_deleted)
Hibernate: 
    select
        c1_0.id,
        c1_0.created_at,
        c1_0.deleted_at,
        c1_0.is_deleted,
        c1_0.name,
        c1_0.parent_id,
        c1_0.updated_at 
    from
        categories c1_0 
    where
        c1_0.id=? 
        and not(c1_0.is_deleted)
Hibernate: 
    update
        categories 
    set
        deleted_at=?,
        is_deleted=?,
        name=?,
        parent_id=?,
        updated_at=? 
    where
        id=?
```

- 개선 후
    - 조회 쿼리를 한 번에 조회 하도록 구현
    - 검증 로직을 분리하여 책임 분리
    - 가독성 및 유지보수성 향상

```sql
Hibernate: 
    select
        c1_0.id,
        c1_0.created_at,
        c1_0.deleted_at,
        c1_0.is_deleted,
        c1_0.name,
        c1_0.parent_id,
        c1_0.updated_at 
    from
        categories c1_0 
    where
        c1_0.id=? 
        and not(c1_0.is_deleted)
Hibernate: 
    select
        c1_0.id,
        c1_0.created_at,
        c1_0.deleted_at,
        c1_0.is_deleted,
        c1_0.name,
        c1_0.parent_id,
        c1_0.updated_at 
    from
        categories c1_0 
    where
        c1_0.id=? 
        and not(c1_0.is_deleted)
```
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
