### PR TITLE
[feat] 옷장 이미지 연동 기능 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/request/ClosetSaveRequest.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/request/ClosetSaveRequest.java
@@ -3,7 +3,14 @@ package org.example.ootoutfitoftoday.domain.closet.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
 
+/**
+ * 옷장 생성을 위한 요청 DTO (Record + Builder + Static Factory Method)
+ * - 이미지는 1장만 등록 가능하며, 선택 사항(nullable)
+ */
+@Builder(access = AccessLevel.PRIVATE)
 public record ClosetSaveRequest(
 
         @NotBlank(message = "옷장 이름은 필수입니다.")
@@ -13,11 +20,23 @@ public record ClosetSaveRequest(
         @Size(max = 255, message = "옷장 설명은 255자를 초과할 수 없습니다.")
         String description,
 
-        @Size(max = 500, message = "이미지 URL은 500자를 초과할 수 없습니다.")
-        String imageUrl,
+        Long imageId,
 
         @NotNull(message = "공개 여부는 필수입니다.")
         Boolean isPublic
 ) {
-}
+    public static ClosetSaveRequest create(
+            String name,
+            String description,
+            Long imageId,
+            Boolean isPublic
+    ) {
 
+        return ClosetSaveRequest.builder()
+                .name(name)
+                .description(description)
+                .imageId(imageId)
+                .isPublic(isPublic)
+                .build();
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/request/ClosetUpdateRequest.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/dto/request/ClosetUpdateRequest.java
@@ -3,7 +3,14 @@ package org.example.ootoutfitoftoday.domain.closet.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
 
+/**
+ * 옷장 정보 수정을 위한 요청 DTO
+ * - 이미지는 1장만 수정 가능하며, 선택 사항(nullable)
+ */
+@Builder(access = AccessLevel.PRIVATE)
 public record ClosetUpdateRequest(
 
         @NotBlank(message = "옷장 이름은 필수입니다.")
@@ -13,10 +20,23 @@ public record ClosetUpdateRequest(
         @Size(max = 255, message = "옷장 설명은 255자를 초과할 수 없습니다.")
         String description,
 
-        @Size(max = 500, message = "이미지 URL은 500자를 초과할 수 없습니다.")
-        String imageUrl,
+        Long imageId,
 
         @NotNull(message = "공개 여부는 필수입니다.")
         Boolean isPublic
 ) {
+    public static ClosetUpdateRequest create(
+            String name,
+            String description,
+            Long imageId,
+            Boolean isPublic
+    ) {
+
+        return ClosetUpdateRequest.builder()
+                .name(name)
+                .description(description)
+                .imageId(imageId)
+                .isPublic(isPublic)
+                .build();
+    }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/entity/Closet.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/entity/Closet.java
@@ -34,6 +34,9 @@ public class Closet extends BaseEntity {
     @Column(length = 255, nullable = true)
     private String description;
 
+    // 제거 예정
+    private String imageUrl;
+
     // 공개 여부 (true: 공개, false: 비공개)
     @Column(nullable = false)
     private Boolean isPublic;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
@@ -10,6 +10,8 @@ import org.example.ootoutfitoftoday.domain.closet.entity.Closet;
 import org.example.ootoutfitoftoday.domain.closet.exception.ClosetErrorCode;
 import org.example.ootoutfitoftoday.domain.closet.exception.ClosetException;
 import org.example.ootoutfitoftoday.domain.closet.repository.ClosetRepository;
+import org.example.ootoutfitoftoday.domain.image.entity.Image;
+import org.example.ootoutfitoftoday.domain.image.service.query.ImageQueryService;
 import org.example.ootoutfitoftoday.domain.user.entity.User;
 import org.example.ootoutfitoftoday.domain.user.service.query.UserQueryService;
 import org.springframework.stereotype.Service;
@@ -24,21 +26,29 @@ public class ClosetCommandServiceImpl implements ClosetCommandService {
 
     private final ClosetRepository closetRepository;
     private final UserQueryService userQueryService;
+    private final ImageQueryService imageQueryService;
 
     // 옷장 등록
     @Override
-    public ClosetSaveResponse createCloset(Long id, ClosetSaveRequest request) {
+    public ClosetSaveResponse createCloset(Long userId, ClosetSaveRequest request) {
 
-        User user = userQueryService.findByIdAndIsDeletedFalse(id);
+        User user = userQueryService.findByIdAndIsDeletedFalse(userId);
+
+        Image image = null;
+        if (request.imageId() != null) {
+            image = imageQueryService.findImageById(request.imageId());
+        }
 
         Closet closet = Closet.create(
                 user,
                 request.name(),
                 request.description(),
-
-                request.imageUrl(),
                 request.isPublic()
         );
+
+        if (image != null) {
+            closet.setClosetImage(image);
+        }
 
         Closet savedCloset = closetRepository.save(closet);
 
@@ -52,7 +62,6 @@ public class ClosetCommandServiceImpl implements ClosetCommandService {
             Long closetId,
             ClosetUpdateRequest request
     ) {
-
         Closet updatedCloset = closetRepository.findById(closetId)
                 .orElseThrow(() -> new ClosetException(ClosetErrorCode.CLOSET_NOT_FOUND));
 
@@ -64,12 +73,18 @@ public class ClosetCommandServiceImpl implements ClosetCommandService {
             throw new ClosetException(ClosetErrorCode.CLOSET_FORBIDDEN);
         }
 
+        Image newImage = null;
+        if (request.imageId() != null) {
+            newImage = imageQueryService.findImageById(request.imageId());
+        }
+
         updatedCloset.update(
                 request.name(),
                 request.description(),
-                request.imageUrl(),
                 request.isPublic()
         );
+
+        updatedCloset.setClosetImage(newImage);
 
         return ClosetUpdateResponse.from(updatedCloset);
     }
@@ -80,7 +95,6 @@ public class ClosetCommandServiceImpl implements ClosetCommandService {
             Long userId,
             Long closetId
     ) {
-
         Closet closet = closetRepository.findById(closetId)
                 .orElseThrow(() -> new ClosetException(ClosetErrorCode.CLOSET_NOT_FOUND));
 

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closet/service/command/ClosetCommandServiceImpl.java
@@ -34,19 +34,15 @@ public class ClosetCommandServiceImpl implements ClosetCommandService {
 
         User user = userQueryService.findByIdAndIsDeletedFalse(userId);
 
-        Image image = null;
-        if (request.imageId() != null) {
-            image = imageQueryService.findImageById(request.imageId());
-        }
-
         Closet closet = Closet.create(
                 user,
                 request.name(),
                 request.description(),
                 request.isPublic()
         );
-
-        if (image != null) {
+        
+        if (request.imageId() != null) {
+            Image image = imageQueryService.findImageById(request.imageId());
             closet.setClosetImage(image);
         }
 

--- a/src/main/java/org/example/ootoutfitoftoday/domain/closetimage/entity/ClosetImage.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/closetimage/entity/ClosetImage.java
@@ -1,0 +1,50 @@
+package org.example.ootoutfitoftoday.domain.closetimage.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.ootoutfitoftoday.common.entity.BaseEntity;
+import org.example.ootoutfitoftoday.domain.image.entity.Image;
+
+/**
+ * [연결 엔티티] ClosetImage: 옷장(Closet)과 이미지(Image)의 1:1 관계를 표현
+ * - 목적: 이미지 정보를 별도 엔티티로 분리하여 SRP를 준수하고, 향후 다른 도메인(Clothes 등)과의 일관성을 유지
+ * - 제약: 하나의 Closet은 하나의 ClosetImage만 참조하며, 이 엔티티는 하나의 Image만 참조
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "closet_images")
+public class ClosetImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * [연관관계] Image와의 1:1 단방향 관계
+     * - 이 연결 엔티티는 Image 도메인의 상세 정보 (S3 경로 등)를 참조
+     * - @OneToOne: 하나의 ClosetImage는 하나의 Image
+     * - nullable = false: 연결 시 Image 정보는 필수
+     */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id", nullable = false, unique = true)
+    private Image image;
+
+    @Builder(access = AccessLevel.PROTECTED)
+    private ClosetImage(Image image) {
+        this.image = image;
+    }
+    
+    public static ClosetImage create(Image image) {
+        return ClosetImage.builder()
+                .image(image)
+                .build();
+    }
+
+    public void updateImage(Image newImage) {
+        this.image = newImage;
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #131 
- 옷장 도메인에 1:1 이미지 연동 기능을 구현
- 기존 옷장 CRUD 로직에 이미지 등록/수정/제거 로직을 통합

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 옷장 (Closet) 도메인에 1:1 이미지 연동 기능을 구현 
- 기존 옷장 CRUD API의 Request DTO에 imageId 필드를 통합하여 이미지 등록, 수정, 제거 로직을 처리하도록 구조를 업데이트
- ClosetImage 엔티티 및 연관관계를 설정하고, Closet 엔티티에 핵심 비즈니스 메서드를 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
추후 확인 예정

## ✅ PR Checklis

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
