### PR TITLE
[feat] 마지막 착용 일시 필드 추가 및 업데이트 로직 구현 

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/entity/Clothes.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/entity/Clothes.java
@@ -12,6 +12,7 @@ import org.example.ootoutfitoftoday.domain.clothes.enums.ClothesColor;
 import org.example.ootoutfitoftoday.domain.clothes.enums.ClothesSize;
 import org.example.ootoutfitoftoday.domain.user.entity.User;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +44,9 @@ public class Clothes extends BaseEntity {
 
     @Column(length = 255, nullable = false)
     private String description;
+
+    @Column(nullable = true)
+    private LocalDateTime lastWornAt;
 
     @OneToMany(mappedBy = "clothes")
     private List<ClothesImage> images = new ArrayList<>();
@@ -102,5 +106,10 @@ public class Clothes extends BaseEntity {
     public void removeImage(ClothesImage image) {
         images.remove(image);
         image.updateClothes(null);
+    }
+
+    // 마지막 착용 일시 갱신 메서드
+    public void updateLastWornAt(LocalDateTime wornAt) {
+        this.lastWornAt = wornAt;
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandService.java
@@ -3,6 +3,7 @@ package org.example.ootoutfitoftoday.domain.clothes.service.command;
 import org.example.ootoutfitoftoday.domain.clothes.dto.request.ClothesRequest;
 import org.example.ootoutfitoftoday.domain.clothes.dto.response.ClothesResponse;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ClothesCommandService {
@@ -18,4 +19,6 @@ public interface ClothesCommandService {
     void deleteClothes(Long userId, Long id);
 
     void clearCategoryFromClothes(List<Long> categoryIds);
+
+    void updateLastWornAt(Long clothesId, LocalDateTime wornAt);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandServiceImpl.java
@@ -14,6 +14,7 @@ import org.example.ootoutfitoftoday.domain.user.service.query.UserQueryService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -95,5 +96,13 @@ public class ClothesCommandServiceImpl implements ClothesCommandService {
     @Override
     public void clearCategoryFromClothes(List<Long> categoryIds) {
         clothesRepository.clearCategoryFromClothes(categoryIds);
+    }
+
+    @Override
+    public void updateLastWornAt(Long clothesId, LocalDateTime wornAt) {
+        Clothes clothes = clothesRepository.findByIdAndIsDeletedFalse(clothesId)
+                .orElseThrow(() -> new ClothesException(ClothesErrorCode.CLOTHES_NOT_FOUND));
+
+        clothes.updateLastWornAt(wornAt);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #213 
- Clothes 엔티티에 마지막 착용 일시(last_worn_at) 필드를 추가
- 이를 외부(WearRecord 도메인)에서 갱신할 수 있는 Service 로직을 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. Clothes 엔티티 구조 변경
- Clothes: lastWornAt 필드(LocalDateTime, nullable = true)를 추가
- 해당 필드를 갱신하는 엔티티 메서드 updateLastWornAt(LocalDateTime wornAt)를 구현

2. Repository 데이터 정합성 강화
- ClothesRepository: updateLastWornAt 로직에서 사용될 findByIdAndIsDeletedFalse(Long id) 메서드를 추가
- 이미 삭제된 옷에 대한 비정상적인 착용 기록 업데이트 시도를 원천적으로 차단

3. Command Service 로직 구현
- ClothesCommandService: updateLastWornAt(Long clothesId, LocalDateTime wornAt) 시그니처를 추가
- ClothesCommandServiceImpl:  ClothesRepository.findByIdAndIsDeletedFalse를 사용하여 옷을 조회하고, 엔티티 메서드를 통해 값을 갱신하도록 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
- 옷 등록 이상 없음
<img width="984" height="362" alt="스크린샷 2025-10-29 01 52 26" src="https://github.com/user-attachments/assets/eb64cea5-bad3-4250-98f4-29904b517e5d" />


## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- lastWornAt 필드는 시스템에 의해 관리되는 필드이므로, Create/Update Request DTO에는 포함하지 않았습니다. 이 설계 방향에 대하여 의견이 있으시면 리뷰를 부탁드립니다.
- ClothesCommandServiceImpl에서 findByIdAndIsDeletedFalse를 사용하여 데이터 정합성을 확보했습니다. 해당 조회 로직의 적절성 검토 부탁드립니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
