### PR TITLE
[feat] 착용 기록 생성 API 구현 

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/controller/WearRecordController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/controller/WearRecordController.java
@@ -1,0 +1,60 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.response.Response;
+import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.request.WearRecordCreateRequest;
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordCreateResponse;
+import org.example.ootoutfitoftoday.domain.wearrecord.exception.WearRecordSuccessCode;
+import org.example.ootoutfitoftoday.domain.wearrecord.service.command.WearRecordCommandService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "착용 기록 관리", description = "옷 착용 기록 및 이력 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/wear-records")
+public class WearRecordController {
+
+    private final WearRecordCommandService wearRecordCommandService;
+
+    /**
+     * 착용 기록 등록
+     *
+     * @param authUser: 인증된 사용자 정보
+     * @param request:  착용 기록 등록 요청 객체 (clothesId 포함)
+     * @return WearRecordCreateResponse: 등록된 기록 ID와 성공 응답 코드
+     */
+    @Operation(
+            summary = "착용 기록 등록",
+            description = "사용자가 특정 옷을 착용했음을 기록하고, 해당 옷의 마지막 착용 일시를 업데이트합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "등록 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 (clothesId 누락 등)"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "404", description = "옷을 찾을 수 없음 (삭제되었거나 권한 없음)")
+            }
+    )
+    @PostMapping
+    public ResponseEntity<Response<WearRecordCreateResponse>> createWearRecord(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody WearRecordCreateRequest request
+    ) {
+        WearRecordCreateResponse response = wearRecordCommandService.createWearRecord(
+                authUser.getUserId(),
+                request
+        );
+
+        return Response.success(response, WearRecordSuccessCode.WEAR_RECORD_CREATED);
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/controller/WearRecordController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/controller/WearRecordController.java
@@ -42,7 +42,8 @@ public class WearRecordController {
                     @ApiResponse(responseCode = "201", description = "등록 성공"),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청 (clothesId 누락 등)"),
                     @ApiResponse(responseCode = "401", description = "인증 실패"),
-                    @ApiResponse(responseCode = "404", description = "옷을 찾을 수 없음 (삭제되었거나 권한 없음)")
+                    @ApiResponse(responseCode = "403", description = "권한 없음 (다른 사용자의 옷에 기록 시도)"),
+                    @ApiResponse(responseCode = "404", description = "옷을 찾을 수 없음 (ID 오류 또는 삭제된 옷)")
             }
     )
     @PostMapping

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/request/WearRecordCreateRequest.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/request/WearRecordCreateRequest.java
@@ -1,0 +1,12 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record WearRecordCreateRequest(
+
+        @NotNull(message = "옷 ID는 필수입니다.")
+        Long clothesId
+) {
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordCreateResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordCreateResponse.java
@@ -1,0 +1,16 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record WearRecordCreateResponse(
+
+        Long wearRecordId
+) {
+    public static WearRecordCreateResponse from(Long wearRecordId) {
+
+        return WearRecordCreateResponse.builder()
+                .wearRecordId(wearRecordId)
+                .build();
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordCreateResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordCreateResponse.java
@@ -1,16 +1,11 @@
 package org.example.ootoutfitoftoday.domain.wearrecord.dto.response;
 
-import lombok.Builder;
-
-@Builder
 public record WearRecordCreateResponse(
 
         Long wearRecordId
 ) {
     public static WearRecordCreateResponse from(Long wearRecordId) {
 
-        return WearRecordCreateResponse.builder()
-                .wearRecordId(wearRecordId)
-                .build();
+        return new WearRecordCreateResponse(wearRecordId);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/entity/WearRecord.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/entity/WearRecord.java
@@ -1,0 +1,58 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.ootoutfitoftoday.common.entity.BaseEntity;
+import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
+import org.example.ootoutfitoftoday.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "wear_records")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WearRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "clothes_id", nullable = false)
+    private Clothes clothes;
+
+    @Column(name = "worn_at", nullable = false)
+    private LocalDateTime wornAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private WearRecord(
+            User user,
+            Clothes clothes,
+            LocalDateTime wornAt
+    ) {
+        this.user = user;
+        this.clothes = clothes;
+        this.wornAt = wornAt;
+    }
+
+    public static WearRecord create(
+            User user,
+            Clothes clothes,
+            LocalDateTime wornAt
+    ) {
+
+        return WearRecord.builder()
+                .user(user)
+                .clothes(clothes)
+                .wornAt(wornAt)
+                .build();
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordErrorCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordErrorCode.java
@@ -1,0 +1,17 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum WearRecordErrorCode implements ErrorCode {
+
+    WEAR_RECORD_FORBIDDEN("WEAR_RECORD_FORBIDDEN", HttpStatus.FORBIDDEN, "착용 기록을 시도하려는 옷에 대한 권한이 없습니다.");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordException.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordException.java
@@ -1,0 +1,11 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.exception;
+
+import org.example.ootoutfitoftoday.common.exception.GlobalException;
+
+public class WearRecordException extends GlobalException {
+
+    public WearRecordException(WearRecordErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordSuccessCode.java
@@ -1,0 +1,17 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.exception.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum WearRecordSuccessCode implements SuccessCode {
+
+    WEAR_RECORD_CREATED("WEAR_RECORD_CREATED", HttpStatus.CREATED, "착용 기록 등록에 성공했습니다.");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/repository/WearRecordRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/repository/WearRecordRepository.java
@@ -1,0 +1,7 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.repository;
+
+import org.example.ootoutfitoftoday.domain.wearrecord.entity.WearRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WearRecordRepository extends JpaRepository<WearRecord, Long> {
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/command/WearRecordCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/command/WearRecordCommandService.java
@@ -1,0 +1,13 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.service.command;
+
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.request.WearRecordCreateRequest;
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordCreateResponse;
+
+public interface WearRecordCommandService {
+
+    // 착용 기록을 생성하고, 해당 옷의 마지막 착용 일시를 업데이트
+    WearRecordCreateResponse createWearRecord(
+            Long userId,
+            WearRecordCreateRequest request
+    );
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/command/WearRecordCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/command/WearRecordCommandServiceImpl.java
@@ -1,0 +1,48 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
+import org.example.ootoutfitoftoday.domain.clothes.service.command.ClothesCommandService;
+import org.example.ootoutfitoftoday.domain.clothes.service.query.ClothesQueryService;
+import org.example.ootoutfitoftoday.domain.user.entity.User;
+import org.example.ootoutfitoftoday.domain.user.service.query.UserQueryService;
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.request.WearRecordCreateRequest;
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordCreateResponse;
+import org.example.ootoutfitoftoday.domain.wearrecord.entity.WearRecord;
+import org.example.ootoutfitoftoday.domain.wearrecord.repository.WearRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WearRecordCommandServiceImpl implements WearRecordCommandService {
+
+    private final WearRecordRepository wearRecordRepository;
+    private final ClothesCommandService clothesCommandService;
+    private final UserQueryService userQueryService;
+    private final ClothesQueryService clothesQueryService;
+
+    @Override
+    public WearRecordCreateResponse createWearRecord(Long userId, WearRecordCreateRequest request) {
+
+
+        User user = userQueryService.findByIdAndIsDeletedFalse(userId);
+
+        Clothes clothes = clothesQueryService.findClothesById(request.clothesId());
+
+        LocalDateTime wornAt = LocalDateTime.now();
+        WearRecord wearRecord = WearRecord.create(user, clothes, wornAt);
+        WearRecord savedRecord = wearRecordRepository.save(wearRecord);
+
+        // Clothes 마지막 착용 일시 업데이트 위임
+        clothesCommandService.updateLastWornAt(
+                request.clothesId(),
+                wornAt
+        );
+
+        return WearRecordCreateResponse.from(savedRecord.getId());
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/command/WearRecordCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/command/WearRecordCommandServiceImpl.java
@@ -9,6 +9,8 @@ import org.example.ootoutfitoftoday.domain.user.service.query.UserQueryService;
 import org.example.ootoutfitoftoday.domain.wearrecord.dto.request.WearRecordCreateRequest;
 import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordCreateResponse;
 import org.example.ootoutfitoftoday.domain.wearrecord.entity.WearRecord;
+import org.example.ootoutfitoftoday.domain.wearrecord.exception.WearRecordErrorCode;
+import org.example.ootoutfitoftoday.domain.wearrecord.exception.WearRecordException;
 import org.example.ootoutfitoftoday.domain.wearrecord.repository.WearRecordRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +34,10 @@ public class WearRecordCommandServiceImpl implements WearRecordCommandService {
         User user = userQueryService.findByIdAndIsDeletedFalse(userId);
 
         Clothes clothes = clothesQueryService.findClothesById(request.clothesId());
+
+        if (!clothes.getUser().getId().equals(userId)) {
+            throw new WearRecordException(WearRecordErrorCode.WEAR_RECORD_FORBIDDEN);
+        }
 
         LocalDateTime wornAt = LocalDateTime.now();
         WearRecord wearRecord = WearRecord.create(user, clothes, wornAt);


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #214
- 사용자가 특정 옷을 착용했음을 기록하는 POST /v1/wear-records API를 구현 
- 이 API는 단순 기록 저장을 넘어, Issue 1에서 구현한 ClothesCommandService를 호출하여 해당 옷의 lastWornAt 필드를 갱신하는 핵심 트리거 역할
- DTO는 Record + Builder + 정적 팩토리 패턴을 사용

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. WearRecord 도메인 기본 구조 정의
- WearRecord: User 및 Clothes 엔티티와 N:1 단방향 매핑을 설정하고, 테이블명을 wear_records (복수형)으로 지정
- DTO 구현: 요청/응답 DTO (WearRecordCreateRequest/Response)를 Java Record, @Builder, 및 정적 팩토리 메서드(from())를 사용하여 구현

3. 핵심 비즈니스 로직 구현 
- WearRecordCommandServiceImpl, WearRecordCommandService 인터페이스와 구현체를 분리하여 구현 
- User 및 Clothes 엔티티 조회 후 WearRecord를 생성/저장
- WearRecord 저장 후, ClothesCommandService.updateLastWornAt()을 호출하여 lastWornAt 갱신 책임을 위임

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

- 201 성공 
<img width="1422" height="732" alt="스크린샷 2025-10-29 04 27 32" src="https://github.com/user-attachments/assets/ea81a0cf-8646-4b78-a989-0515360e7263" />

- 400 에러
<img width="1418" height="545" alt="스크린샷 2025-10-29 04 28 48" src="https://github.com/user-attachments/assets/a83a56f9-6fe3-4886-bace-a7910937597d" />

- 401 에러

<img width="1418" height="434" alt="스크린샷 2025-10-29 04 29 40" src="https://github.com/user-attachments/assets/aeab1932-6ec7-40c0-973a-52fff1e6c5c4" />

- 404 에러
<img width="1418" height="545" alt="스크린샷 2025-10-29 04 27 56" src="https://github.com/user-attachments/assets/d4e1ba94-cc91-4b9a-bc16-9737d85ffac7" />

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
