### PR TITLE
[feat] 사용자 착용 이력 조회 API 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/controller/WearRecordController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/controller/WearRecordController.java
@@ -6,18 +6,22 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.response.PageResponse;
 import org.example.ootoutfitoftoday.common.response.Response;
 import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
 import org.example.ootoutfitoftoday.domain.wearrecord.dto.request.WearRecordCreateRequest;
 import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordCreateResponse;
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordGetMyResponse;
 import org.example.ootoutfitoftoday.domain.wearrecord.exception.WearRecordSuccessCode;
 import org.example.ootoutfitoftoday.domain.wearrecord.service.command.WearRecordCommandService;
+import org.example.ootoutfitoftoday.domain.wearrecord.service.query.WearRecordQueryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "착용 기록 관리", description = "옷 착용 기록 및 이력 관련 API")
 @RestController
@@ -26,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class WearRecordController {
 
     private final WearRecordCommandService wearRecordCommandService;
+    private final WearRecordQueryService wearRecordQueryService;
 
     /**
      * 착용 기록 등록
@@ -57,5 +62,48 @@ public class WearRecordController {
         );
 
         return Response.success(response, WearRecordSuccessCode.WEAR_RECORD_CREATED);
+    }
+
+    /**
+     * 내 착용 기록 리스트 조회
+     *
+     * @param authUser:  인증된 사용자 정보
+     * @param page:      페이지 번호 (0부터 시작)
+     * @param size:      페이지 크기
+     * @param sort:      정렬 기준 필드 (기본값: wornAt)
+     * @param direction: 정렬 방향 (기본값: DESC)
+     * @return Page<WearRecordGetMyResponse>: 내 착용 기록 리스트
+     */
+    @Operation(
+            summary = "내 착용 기록 리스트 조회",
+            description = "로그인한 사용자의 전체 착용 기록을 최신순(wornAt DESC)으로 페이징하여 조회합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패")
+            }
+    )
+    @GetMapping
+    public ResponseEntity<PageResponse<WearRecordGetMyResponse>> getMyWearRecords(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "wornAt") String sort,
+            @RequestParam(defaultValue = "DESC") String direction
+    ) {
+        Sort.Direction sortDirection = Sort.Direction.fromString(direction);
+
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(sortDirection, sort)
+        );
+
+        Page<WearRecordGetMyResponse> responsePage = wearRecordQueryService.getMyWearRecords(
+                authUser.getUserId(),
+                pageable
+        );
+
+        return PageResponse.success(responsePage, WearRecordSuccessCode.WEAR_RECORDS_GET_OK);
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordGetMyResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordGetMyResponse.java
@@ -1,0 +1,39 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.dto.response;
+
+import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
+import org.example.ootoutfitoftoday.domain.clothesImage.entity.ClothesImage;
+import org.example.ootoutfitoftoday.domain.wearrecord.entity.WearRecord;
+
+import java.time.LocalDateTime;
+
+public record WearRecordGetMyResponse(
+
+        Long wearRecordId,
+        LocalDateTime wornAt,
+        Long clothesId,
+        String clothesName,
+        String clothesImageUrl
+) {
+    public static WearRecordGetMyResponse from(WearRecord wearRecord) {
+        Clothes clothes = wearRecord.getClothes();
+
+        String name = clothes.getDescription();
+
+        String imageUrl = null;
+        if (clothes.getImages() != null && !clothes.getImages().isEmpty()) {
+            ClothesImage firstImage = clothes.getImages().get(0);
+            if (firstImage != null) {
+                // ClothesImage 엔티티를 거쳐 Image 엔티티의 getUrl()을 호출
+                imageUrl = firstImage.getImage().getUrl();
+            }
+        }
+
+        return new WearRecordGetMyResponse(
+                wearRecord.getId(),
+                wearRecord.getWornAt(),
+                clothes.getId(),
+                name,
+                imageUrl
+        );
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordGetMyResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/dto/response/WearRecordGetMyResponse.java
@@ -1,7 +1,6 @@
 package org.example.ootoutfitoftoday.domain.wearrecord.dto.response;
 
 import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
-import org.example.ootoutfitoftoday.domain.clothesImage.entity.ClothesImage;
 import org.example.ootoutfitoftoday.domain.wearrecord.entity.WearRecord;
 
 import java.time.LocalDateTime;
@@ -20,12 +19,13 @@ public record WearRecordGetMyResponse(
         String name = clothes.getDescription();
 
         String imageUrl = null;
+
         if (clothes.getImages() != null && !clothes.getImages().isEmpty()) {
-            ClothesImage firstImage = clothes.getImages().get(0);
-            if (firstImage != null) {
-                // ClothesImage 엔티티를 거쳐 Image 엔티티의 getUrl()을 호출
-                imageUrl = firstImage.getImage().getUrl();
-            }
+            imageUrl = clothes.getImages().stream()
+                    .filter(image -> Boolean.TRUE.equals(image.getIsMain()))
+                    .findFirst()
+                    .map(mainImage -> mainImage.getImage().getUrl()) // URL로 변환
+                    .orElse(clothes.getImages().get(0).getImage().getUrl());
         }
 
         return new WearRecordGetMyResponse(

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/exception/WearRecordSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum WearRecordSuccessCode implements SuccessCode {
 
-    WEAR_RECORD_CREATED("WEAR_RECORD_CREATED", HttpStatus.CREATED, "착용 기록 등록에 성공했습니다.");
+    WEAR_RECORD_CREATED("WEAR_RECORD_CREATED", HttpStatus.CREATED, "착용 기록 등록에 성공했습니다."),
+    WEAR_RECORDS_GET_OK("WEAR_RECORDS_GET_OK", HttpStatus.OK, "착용 이력 리스트를 조회했습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/repository/WearRecordRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/repository/WearRecordRepository.java
@@ -1,7 +1,23 @@
 package org.example.ootoutfitoftoday.domain.wearrecord.repository;
 
 import org.example.ootoutfitoftoday.domain.wearrecord.entity.WearRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface WearRecordRepository extends JpaRepository<WearRecord, Long> {
+
+    // 특정 사용자의 착용 기록을 페이징하여 조회
+    @Query(value = "SELECT wr FROM WearRecord wr " +
+            "JOIN FETCH wr.user u " +
+            "JOIN FETCH wr.clothes c " +
+            "WHERE u.id = :userId " +
+            "ORDER BY wr.wornAt DESC",
+            countQuery = "SELECT count(wr) FROM WearRecord wr WHERE wr.user.id = :userId")
+    Page<WearRecord> findMyWearRecordsWithClothes(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/repository/WearRecordRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/repository/WearRecordRepository.java
@@ -10,11 +10,12 @@ import org.springframework.data.repository.query.Param;
 public interface WearRecordRepository extends JpaRepository<WearRecord, Long> {
 
     // 특정 사용자의 착용 기록을 페이징하여 조회
-    @Query(value = "SELECT wr FROM WearRecord wr " +
+    @Query(value = "SELECT DISTINCT wr FROM WearRecord wr " +
             "JOIN FETCH wr.user u " +
             "JOIN FETCH wr.clothes c " +
-            "WHERE u.id = :userId " +
-            "ORDER BY wr.wornAt DESC",
+            "LEFT JOIN FETCH c.images ci " +
+            "LEFT JOIN FETCH ci.image i " +
+            "WHERE u.id = :userId",
             countQuery = "SELECT count(wr) FROM WearRecord wr WHERE wr.user.id = :userId")
     Page<WearRecord> findMyWearRecordsWithClothes(
             @Param("userId") Long userId,

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/query/WearRecordQueryService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/query/WearRecordQueryService.java
@@ -1,0 +1,14 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.service.query;
+
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordGetMyResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface WearRecordQueryService {
+
+    // 사용자 ID 기반으로 자신의 착용 기록을 페이징하여 조회
+    Page<WearRecordGetMyResponse> getMyWearRecords(
+            Long userId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/query/WearRecordQueryServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/wearrecord/service/query/WearRecordQueryServiceImpl.java
@@ -1,0 +1,34 @@
+package org.example.ootoutfitoftoday.domain.wearrecord.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.domain.wearrecord.dto.response.WearRecordGetMyResponse;
+import org.example.ootoutfitoftoday.domain.wearrecord.entity.WearRecord;
+import org.example.ootoutfitoftoday.domain.wearrecord.repository.WearRecordRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WearRecordQueryServiceImpl implements WearRecordQueryService {
+
+    private final WearRecordRepository wearRecordRepository;
+
+    // 내 착용 기록 리스트 조회
+    @Override
+    public Page<WearRecordGetMyResponse> getMyWearRecords(
+            Long userId,
+            Pageable pageable
+    ) {
+
+        Page<WearRecord> wearRecords =
+                wearRecordRepository.findMyWearRecordsWithClothes(
+                        userId,
+                        pageable
+                );
+
+        return wearRecords.map(WearRecordGetMyResponse::from);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #215 
- 현재 로그인한 사용자 본인의 전체 옷 착용 이력 목록을 조회하는 API 기능을 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1.  Repository 정의
    - `WearRecordRepository`에 `findAllByUserIdOrderByWornAtDesc` 메서드를 정의하여 사용자의 착용 기록을 최신순으로 조회하는 기능을 준비

2.  Service 로직 구현
    - `WearRecordQueryService`와 `WearRecordQueryServiceImpl`을 구현하여 Repository로부터 데이터를 조회하고 DTO로 변환하는 비즈니스 로직을 구현
    - 핵심: N+1 문제 방지**를 위해 JOIN FETCH를 사용하여 WearRecord 조회 시 연관된 Clothes 정보를 단 한 번의 쿼리로 함께 가져오도록 최적화

3.  Controller 및 API 엔드포인트 구현
    - `WearRecordController`에 *'GET /v1/wear-records` 엔드포인트를 구현하여 인증된 사용자의 요청을 처리하도록 함

4.  **DTO 및 오류 수정:**
    - `WearRecordGetMyResponse` DTO에서 이미지 URL을 가져오는 로직을 `firstImage.getImage().getUrl()`로 수정
    - `ClothesImage`와 `Image` 엔티티 간의 **1:1 연관관계 구조**에 맞도록 수정했습니다 (이전 빌드 오류 해결)

5.  **성공 코드 추가:**
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
- 200 OK
<img width="1419" height="843" alt="스크린샷 2025-10-30 21 46 56" src="https://github.com/user-attachments/assets/36173579-0112-441e-99e6-24c9a45f2e8e" />

- 200 OK(빈 리스트)
<img width="1419" height="689" alt="스크린샷 2025-10-30 21 45 46" src="https://github.com/user-attachments/assets/597c5305-7131-4442-bcab-5032e560f054" />

- 401 에러
<img width="1419" height="486" alt="스크린샷 2025-10-30 21 43 40" src="https://github.com/user-attachments/assets/2f4b412e-9fb6-463f-9d4e-d0a7310f902e" />

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
