### PR TITLE
[feat] 사용자별 추천 기록 생성 API 구현

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/common/config/ClockConfig.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/config/ClockConfig.java
@@ -1,0 +1,24 @@
+package org.example.ootoutfitoftoday.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    /**
+     * Clock 빈을 정의
+     * 시스템 기본 시간대(systemDefaultZone)를 사용하는 Clock을 생성하여 Spring IoC 컨테이너에 등록
+     * Service, Scheduler 등에서 LocalDate.now(clock) 형태로 주입받아 사용하며,
+     * 테스트 시에는 Mock Clock으로 대체하여 시간 의존성을 제거하고 안정적인 테스트를 가능하게 함
+     *
+     * @return 시스템 기본 Clock 객체
+     */
+    @Bean
+    public Clock clock() {
+
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/controller/RecommendationController.java
@@ -1,0 +1,60 @@
+package org.example.ootoutfitoftoday.domain.recommendation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.response.Response;
+import org.example.ootoutfitoftoday.domain.auth.dto.AuthUser;
+import org.example.ootoutfitoftoday.domain.recommendation.dto.response.RecommendationCreateResponse;
+import org.example.ootoutfitoftoday.domain.recommendation.exception.RecommendationSuccessCode;
+import org.example.ootoutfitoftoday.domain.recommendation.service.command.RecommendationCommandService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "추천 기록 관리", description = "기부/판매 추천 기록 생성 및 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/recommendations")
+public class RecommendationController {
+
+    private final RecommendationCommandService recommendationCommandService;
+
+    /**
+     * 추천 기록 생성 (수동 호출 및 기준선 측정용)
+     * <p>
+     * 사용자의 모든 옷을 동기적으로 조회
+     * 1년 이상 착용하지 않은 옷에 대해 판매 또는 기부 추천 기록을 생성
+     * 생성된 각 추천 기록의 상세 정보를 리스트로 반환
+     *
+     * @param authUser 인증된 사용자 정보
+     * @return List<RecommendationCreateResponse>: 생성된 추천 기록 DTO 목록
+     */
+    @Operation(
+            summary = "추천 기록 수동 생성",
+            description = """
+                    로그인한 사용자의 옷을 동기적으로 조회하여 1년 이상 미착용 옷에 대한 판매 또는 기부 추천 기록을 생성합니다.
+                    """,
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "추천 기록 생성 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 로직 오류")
+            }
+    )
+    @PostMapping
+    public ResponseEntity<Response<List<RecommendationCreateResponse>>> generateRecommendations(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        List<RecommendationCreateResponse> responses = recommendationCommandService.generateRecommendations(authUser.getUserId());
+
+        return Response.success(responses, RecommendationSuccessCode.RECOMMENDATION_CREATED);
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/dto/response/RecommendationCreateResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/dto/response/RecommendationCreateResponse.java
@@ -1,0 +1,39 @@
+package org.example.ootoutfitoftoday.domain.recommendation.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.example.ootoutfitoftoday.domain.recommendation.entity.Recommendation;
+import org.example.ootoutfitoftoday.domain.recommendation.status.RecommendationStatus;
+import org.example.ootoutfitoftoday.domain.recommendation.type.RecommendationType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 추천 기록 생성 응답 DTO
+ */
+@Builder(access = AccessLevel.PRIVATE)
+public record RecommendationCreateResponse(
+
+        Long recommendationId,
+        Long userId,
+        Long clothesId,
+        RecommendationType type,
+        String reason,
+        RecommendationStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static RecommendationCreateResponse from(Recommendation recommendation) {
+
+        return RecommendationCreateResponse.builder()
+                .recommendationId(recommendation.getId())
+                .userId(recommendation.getUser().getId())
+                .clothesId(recommendation.getClothes().getId())
+                .type(recommendation.getType())
+                .reason(recommendation.getReason())
+                .status(recommendation.getStatus())
+                .createdAt(recommendation.getCreatedAt())
+                .updatedAt(recommendation.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/exception/RecommendationErrorCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/exception/RecommendationErrorCode.java
@@ -1,0 +1,20 @@
+package org.example.ootoutfitoftoday.domain.recommendation.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecommendationErrorCode implements ErrorCode {
+
+    INVALID_RECOMMENDATION_TYPE("INVALID_RECOMMENDATION_TYPE", HttpStatus.BAD_REQUEST, "잘못된 추천 타입입니다."),
+    INVALID_STATUS_UPDATE("INVALID_STATUS_UPDATE", HttpStatus.BAD_REQUEST, "현재 상태에서 변경할 수 없는 상태입니다."),
+    RECOMMENDATION_NOT_FOUND("RECOMMENDATION_NOT_FOUND", HttpStatus.NOT_FOUND, "해당 추천 기록을 찾을 수 없습니다."),
+    RECOMMENDATION_PROCESSING_ERROR("RECOMMENDATION_PROCESSING_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "추천 기록 처리 중 알 수 없는 오류가 발생했습니다.");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/exception/RecommendationException.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/exception/RecommendationException.java
@@ -1,0 +1,10 @@
+package org.example.ootoutfitoftoday.domain.recommendation.exception;
+
+import org.example.ootoutfitoftoday.common.exception.GlobalException;
+
+public class RecommendationException extends GlobalException {
+
+    public RecommendationException(RecommendationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/exception/RecommendationSuccessCode.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/exception/RecommendationSuccessCode.java
@@ -1,0 +1,19 @@
+package org.example.ootoutfitoftoday.domain.recommendation.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.common.exception.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecommendationSuccessCode implements SuccessCode {
+
+    RECOMMENDATION_CREATED("RECOMMENDATION_CREATED", HttpStatus.CREATED, "추천 기록 생성 성공"),
+    RECOMMENDATION_GET_OK("RECOMMENDATION_GET_OK", HttpStatus.OK, "추천 기록 조회 성공"),
+    RECOMMENDATION_UPDATE_OK("RECOMMENDATION_UPDATE_OK", HttpStatus.OK, "추천 기록 상태 변경 성공");
+    
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/service/command/RecommendationCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/service/command/RecommendationCommandService.java
@@ -1,0 +1,19 @@
+package org.example.ootoutfitoftoday.domain.recommendation.service.command;
+
+import org.example.ootoutfitoftoday.domain.recommendation.dto.response.RecommendationCreateResponse;
+
+import java.util.List;
+
+public interface RecommendationCommandService {
+
+    /**
+     * 사용자에게 기부/판매 추천 기록을 생성
+     * <p>
+     * 초기 성능 기준선 확보를 위해 동기적으로 구현
+     * (추후 Spring Batch로 고도화될 예정)
+     *
+     * @param userId 추천을 생성할 대상 사용자 ID
+     * @return 생성된 추천 기록의 DTO 목록
+     */
+    List<RecommendationCreateResponse> generateRecommendations(Long userId);
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/service/command/RecommendationCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/recommendation/service/command/RecommendationCommandServiceImpl.java
@@ -1,0 +1,79 @@
+package org.example.ootoutfitoftoday.domain.recommendation.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
+import org.example.ootoutfitoftoday.domain.clothes.service.query.ClothesQueryService;
+import org.example.ootoutfitoftoday.domain.recommendation.dto.response.RecommendationCreateResponse;
+import org.example.ootoutfitoftoday.domain.recommendation.entity.Recommendation;
+import org.example.ootoutfitoftoday.domain.recommendation.repository.RecommendationRepository;
+import org.example.ootoutfitoftoday.domain.recommendation.type.RecommendationType;
+import org.example.ootoutfitoftoday.domain.user.entity.User;
+import org.example.ootoutfitoftoday.domain.user.service.query.UserQueryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecommendationCommandServiceImpl implements RecommendationCommandService {
+
+    private final RecommendationRepository recommendationRepository;
+    private final ClothesQueryService clothesQueryService;
+    private final UserQueryService userQueryService;
+
+    // 사용자에게 기부/판매 추천 기록을 생성
+    @Override
+    public List<RecommendationCreateResponse> generateRecommendations(Long userId) {
+
+        User user = userQueryService.findByIdAndIsDeletedFalse(userId);
+
+        List<Clothes> clothesList = clothesQueryService.findAllClothesByUserId(userId);
+
+        // 추천 조건 검사 + 엔티티 생성 (각 옷마다 판매/기부 2개의 추천 생성)
+        List<Recommendation> recommendations = clothesList.stream()
+                .filter(this::isUnwornForOneYear)
+                .flatMap(clothes -> List.of(
+                        // 판매 추천
+                        Recommendation.createForUnwornClothes(
+                                user,
+                                clothes,
+                                RecommendationType.SALE,
+                                "마지막 착용일이 1년 이상 경과"
+                        ),
+                        // 기부 추천
+                        Recommendation.createForUnwornClothes(
+                                user,
+                                clothes,
+                                RecommendationType.DONATION,
+                                "마지막 착용일이 1년 이상 경과"
+                        )
+                ).stream())
+                .toList();
+
+        List<Recommendation> savedRecommendations = recommendationRepository.saveAll(recommendations);
+
+        return savedRecommendations.stream()
+                .map(RecommendationCreateResponse::from)
+                .toList();
+    }
+
+    // 마지막 착용일이 1년 이상 경과했는지 확인
+    private boolean isUnwornForOneYear(Clothes clothes) {
+        LocalDateTime lastWornAt = clothes.getLastWornAt();
+
+        // lastWornAt이 null이면 착용한 적이 없으므로 추천 대상
+        if (lastWornAt == null) {
+            return true;
+        }
+
+        // lastWornAt을 LocalDate로 변환하여 1년 전과 비교
+        LocalDate lastWornDate = lastWornAt.toLocalDate();
+        LocalDate oneYearAgo = LocalDate.now().minusYears(1);
+
+        return lastWornDate.isBefore(oneYearAgo);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #222
- Recommendation 생성 API를 구현했습니다. 
- 모든 옷 데이터를 동기적으로 조회하여 1년 이상 미착용된 옷에 대한 추천 기록을 생성하며, 이는 향후 성능 고도화를 위한 기준점 역할을 합니다.

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Service 인터페이스 확립: RecommendationCommandService 인터페이스와 구현체를 정의하여 추천 생성 로직을 캡슐화
- 핵심 로직 구현: 1년 이상 미착용된 옷에 대해 판매(SALE}와 기부(DONATION) 두 종류의 추천 기록을 생성하고 saveAll()로 일괄 저장

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

- 성공 응답 (추천 대상이 없어서 빈 리스트 반환)
<img width="1408" height="614" alt="스크린샷 2025-11-02 03 39 18" src="https://github.com/user-attachments/assets/f91bbdfb-cbaa-47a1-a5ac-900f08391df0" />

- 에러 응답
<img width="1408" height="510" alt="스크린샷 2025-11-02 03 40 43" src="https://github.com/user-attachments/assets/b6e361db-572b-44ff-8eac-818ce4688b79" />

## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 동기식 로직: 현재 generateRecommendations 로직은 향후 배치 고도화를 위한 성능 기준선입니다. for-loop 대신 Stream을 사용했지만, 대량 데이터에 대한 성능 부하는 Scheduler 및 Batch에서 개선될 예정입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
