### PR TITLE
[fix] SalePostImage 엔티티와 DB 스키마 불일치 해결

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostImageResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostImageResponse.java
@@ -14,8 +14,8 @@ public class SalePostImageResponse {
 
     public static SalePostImageResponse from(SalePostImage salePostImage) {
         return SalePostImageResponse.builder()
-                .imageId(salePostImage.getImage().getId())
-                .imageUrl(salePostImage.getImage().getUrl())
+                .imageId(salePostImage.getId())
+                .imageUrl(salePostImage.getImageUrl())
                 .displayOrder(salePostImage.getDisplayOrder())
                 .isMain(salePostImage.getIsMain())
                 .build();

--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostListResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostListResponse.java
@@ -54,6 +54,6 @@ public class SalePostListResponse {
             return null;
         }
 
-        return salePost.getImages().get(0).getImage().getUrl();
+        return salePost.getImages().get(0).getImageUrl();
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostPublicListResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostPublicListResponse.java
@@ -50,6 +50,6 @@ public class SalePostPublicListResponse {
             return null;
         }
 
-        return salePost.getImages().get(0).getImage().getUrl();
+        return salePost.getImages().get(0).getImageUrl();
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostSummaryResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/dto/response/SalePostSummaryResponse.java
@@ -45,6 +45,6 @@ public class SalePostSummaryResponse {
             return null;
         }
 
-        return salePost.getImages().get(0).getImage().getUrl();
+        return salePost.getImages().get(0).getImageUrl();
     }
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/entity/SalePostImage.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/entity/SalePostImage.java
@@ -20,6 +20,9 @@ public class SalePostImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 500)
+    private String imageUrl;
+
     @Column(nullable = false)
     private Integer displayOrder;
 
@@ -27,20 +30,16 @@ public class SalePostImage extends BaseEntity {
     private Boolean isMain;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "image_id", nullable = false)
-    private Image image;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sale_post_id", nullable = false)
     private SalePost salePost;
 
     @Builder(access = AccessLevel.PROTECTED)
     private SalePostImage(
-            Image image,
+            String imageUrl,
             Integer displayOrder,
             Boolean isMain
     ) {
-        this.image = image;
+        this.imageUrl = imageUrl;
         this.displayOrder = displayOrder;
         this.isMain = isMain;
     }
@@ -53,7 +52,7 @@ public class SalePostImage extends BaseEntity {
         validateImage(image);
 
         return SalePostImage.builder()
-                .image(image)
+                .imageUrl(image.getUrl())
                 .displayOrder(displayOrder)
                 .isMain(isMain)
                 .build();

--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/service/cache/SalePostCacheServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/service/cache/SalePostCacheServiceImpl.java
@@ -60,10 +60,9 @@ public class SalePostCacheServiceImpl implements SalePostCacheService {
                     s.status,
                     s.trade_address,
                     ST_AsText(s.trade_location) AS trade_location,
-                    (SELECT i.url 
-                     FROM sale_post_images spi 
-                     JOIN images i ON spi.image_id = i.id 
-                     WHERE spi.sale_post_id = s.id 
+                    (SELECT spi.image_url
+                     FROM sale_post_images spi
+                     WHERE spi.sale_post_id = s.id
                      AND spi.is_main = TRUE
                      AND spi.is_deleted = FALSE
                      LIMIT 1) AS thumbnail_url,

--- a/src/main/java/org/example/ootoutfitoftoday/domain/salepost/service/query/SalePostQueryServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/salepost/service/query/SalePostQueryServiceImpl.java
@@ -204,9 +204,8 @@ public class SalePostQueryServiceImpl implements SalePostQueryService {
                     s.status,
                     s.trade_address,
                     ST_AsText(s.trade_location) AS trade_location,
-                    (SELECT i.url
+                    (SELECT spi.image_url
                      FROM sale_post_images spi
-                     JOIN images i ON spi.image_id = i.id
                      WHERE spi.sale_post_id = s.id
                      AND spi.is_main = TRUE
                      AND spi.is_deleted = FALSE


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #414

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

-  판매글 생성 시 `image_url` NOT NULL 제약조건 위반으로 실패하는 문제를 해결

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
- 판매글 생성 시 이미지 데이터 잘 들어감
<img width="1270" height="769" alt="스크린샷 2025-11-18 21 16 13" src="https://github.com/user-attachments/assets/f971ba63-b432-4381-8521-82d4096abbb5" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
